### PR TITLE
Move interactive marker launch from teleop into control launch file

### DIFF
--- a/husky_control/launch/control.launch
+++ b/husky_control/launch/control.launch
@@ -9,6 +9,8 @@
     <rosparam command="load" file="$(find husky_control)/config/localization.yaml" />
   </node>
 
+  <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server" output="screen"/>
+
   <node pkg="twist_mux" type="twist_mux" name="twist_mux">
     <rosparam command="load" file="$(find husky_control)/config/twist_mux.yaml" />
     <remap from="cmd_vel_out" to="husky_velocity_controller/cmd_vel"/>

--- a/husky_control/launch/teleop.launch
+++ b/husky_control/launch/teleop.launch
@@ -15,6 +15,4 @@
     <node pkg="teleop_twist_joy" type="teleop_node" name="teleop_twist_joy"/>
   </group>
 
-  <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server" output="screen"/>
-
 </launch>


### PR DESCRIPTION
@mikepurvis, thoughts?

Would like to align on details like this, with the hope of eventually transitioning to a standard bringup scheme for ros_control'ed platforms
