### PR TITLE
Remapping the move_base topic to be compatible with cpr autonomy core.

### DIFF
--- a/husky_control/config/twist_mux.yaml
+++ b/husky_control/config/twist_mux.yaml
@@ -7,8 +7,8 @@ topics:
   topic   : twist_marker_server/cmd_vel
   timeout : 0.5
   priority: 8
-- name    : move_base
-  topic   : move_base/cmd_vel
+- name    : autonomy
+  topic   : platform_control/cmd_vel
   timeout : 0.5
   priority: 2
 - name    : external

--- a/husky_navigation/launch/move_base.launch
+++ b/husky_navigation/launch/move_base.launch
@@ -54,8 +54,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
     <param name="global_costmap/width" value="100.0" if="$(arg no_static_map)"/>
     <param name="global_costmap/height" value="100.0" if="$(arg no_static_map)"/>
 
-    <!-- Remap into namespace for cmd_vel_mux switching -->
-    <remap from="cmd_vel" to="~cmd_vel" />
+    <!-- Remap move_base cmd_vel so generic /cmd_vel can be used as a catchall in twist_mux -->
+    <remap from="cmd_vel" to="platform_control/cmd_vel" />
 
   </node>
 

--- a/husky_navigation/launch/move_base.launch
+++ b/husky_navigation/launch/move_base.launch
@@ -53,10 +53,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
     <rosparam file="$(find husky_navigation)/config/costmap_global_laser.yaml" command="load" ns="global_costmap" if="$(arg no_static_map)"/>
     <param name="global_costmap/width" value="100.0" if="$(arg no_static_map)"/>
     <param name="global_costmap/height" value="100.0" if="$(arg no_static_map)"/>
-
-    <!-- Remap move_base cmd_vel so generic /cmd_vel can be used as a catchall in twist_mux -->
-    <remap from="cmd_vel" to="platform_control/cmd_vel" />
-
   </node>
 
 </launch>


### PR DESCRIPTION
@paulbovbel This is the easiest fix I can do to make cpr autonomy core compatible (without breaking API) and doesn't take out a bunch of existing functionality.
