### PR TITLE
[husky_description/CMakeLists.txt] fix position to exec roslaunch_add_file_check

### DIFF
--- a/husky_description/CMakeLists.txt
+++ b/husky_description/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(husky_description)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin)
 
 catkin_package()
 catkin_add_env_hooks(50.husky_description
   SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
 
-roslaunch_add_file_check(launch)
-
 install(
   DIRECTORY launch meshes urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch DEPENDENCIES ${catkin_EXPORTED_TARGETS})
+endif()

--- a/husky_description/package.xml
+++ b/husky_description/package.xml
@@ -19,13 +19,12 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roslaunch</build_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>roslaunch</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>ur_description</run_depend>
   <run_depend>lms1xx</run_depend>
-
 
   <export>
   </export>


### PR DESCRIPTION
Currently if `ur_description` which is `run_depend` of `husky_description` is installed from source, `roslaunch_add_file_check` fails because `ur_description` may be built after this package, and its path is not yet in `ROS_PACKAGE_PATH` when `roslaunch_add_file_check`.
