### PR TITLE
Dependency addition

### DIFF
--- a/husky_ur5_moveit_config/package.xml
+++ b/husky_ur5_moveit_config/package.xml
@@ -17,6 +17,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
 
+
+  <run_depend>moveit_msgs</run_depend>
+  <run_depend>moveit_core</run_depend>
+  <run_depend>moveit_ros</run_depend>
+
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/husky_ur5_moveit_config/package.xml
+++ b/husky_ur5_moveit_config/package.xml
@@ -18,10 +18,8 @@
   <build_depend>roslaunch</build_depend>
 
 
-  <run_depend>moveit_msgs</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>moveit_ros</run_depend>
 
+  <run_depend>ur_kinematics</run_depend>
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>


### PR DESCRIPTION
Users may find themselves without the fast, customized UR5 Kinematics planning plugin unless they have this package installed. Error isn't apparent at runtime until it starts crashing.
