### PR TITLE
wheel.urdf.xacro: swap iyy, izz inertias

### DIFF
--- a/husky_description/urdf/wheel.urdf.xacro
+++ b/husky_description/urdf/wheel.urdf.xacro
@@ -30,7 +30,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 			<inertial>
 				<mass value="2.637" />
 				<origin xyz="0 0 0" />
-				<inertia  ixx="0.02467" ixy="0" ixz="0" iyy="0.02467" iyz="0" izz="0.04411" />
+				<inertia  ixx="0.02467" ixy="0" ixz="0" iyy="0.04411" iyz="0" izz="0.02467" />
 			</inertial>
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0" />


### PR DESCRIPTION
Fixes #34.

The cylinder collision has a 90 degree roll rotation on line 42, so that the cylinder axis of symmetry should be the Y axis, instead of the Z. I noticed this when visualizing the inertia in gazebo7. I can attach a screenshot if desired.
