### PR TITLE
Dual UR5 URDF Fixes: IMU rotation, PTU mount

### DIFF
--- a/husky_description/urdf/dual_arm_husky.urdf.xacro
+++ b/husky_description/urdf/dual_arm_husky.urdf.xacro
@@ -483,7 +483,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </joint>
   <!-- Connect PTU to Husky bulkhead -->
   <joint name="husky_ptu_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0.365 0 0.19876"/>
+    <origin rpy="0 0 0" xyz="0.345 0.010414 0.19876"/><!-- x-translation still needs to be measured -->
     <parent link="dual_arm_bulkhead_link"/>
     <child link="husky_ptu_base_link"/>
   </joint>

--- a/husky_description/urdf/dual_arm_husky.urdf.xacro
+++ b/husky_description/urdf/dual_arm_husky.urdf.xacro
@@ -112,7 +112,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <!-- Can be modified with environment variables in /etc/ros/setup.bash -->
   <link name="imu_link"/>
   <joint name="imu_joint" type="fixed">
-    <origin rpy="0 -1.5708 3.1416" xyz="0.19 0 0.149"/>
+    <!-- <origin xyz="$(optenv HUSKY_IMU_XYZ 0.19 0 0.149)" rpy="$(optenv HUSKY_IMU_RPY 0 -1.5708 3.1416)" /> -->
+    <origin rpy="-1.5708 0 0" xyz="0.19 0 0.149"/>
     <parent link="base_link"/>
     <child link="imu_link"/>
   </joint>

--- a/husky_description/urdf/dual_arm_husky.urdf.xacro
+++ b/husky_description/urdf/dual_arm_husky.urdf.xacro
@@ -1180,7 +1180,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     </sensor>
   </gazebo>
   <joint name="bumblebee2_mount_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0 0.00"/>
+    <origin rpy="0 0 0" xyz="0 0 0.02224"/>
     <parent link="husky_ptu_mount_link"/>
     <child link="bumblebee2"/>
   </joint>


### PR DESCRIPTION
This is another set of necessary fixes for the Dual UR5 Husky:

1. As discussed with support re the ROS EKF not working, I've noticed that the IMU mounting location was off. Using another IMU of the same make and model I found the likely mounting orientation to be negative 90 degrees roll. The orientation was hard-coded, I haven't activated the environment variable yet as I believe that will be done during proper integration of the branch. This change allows the ROS EKF to work.
2. The orientation corrections for the PTU mounting in #36 weren't enough as observation using an external sensor confirmed (as highlighted in #38). The y-translation is taken from the [data sheet](http://www.flir.com/uploadedFiles/CVS_Americas/MCS/Products/PTU-E46/FLIR-E46-Datasheet.pdf) and the x-translation guesstimated from photographs I've taken and approximately confirmed by the external observation (a give-away indicator was that the PTU was mounted behind and not on top of the screws adjoining the front laser mounting plate).

As discussed in #38, the PTU mounting bracket shown in the data sheet is not part of the repository. I've opened an upstream issue (https://github.com/ros-drivers/flir_ptu/issues/31). [For the larger D48, adding the mounting bracket as part of adding the whole D48 was proposed by @jeff-o in https://github.com/ros-drivers/flir_ptu/pull/17 awaiting integration.]

### Before
![screenshot-2016-12-03_16 56 02](https://cloud.githubusercontent.com/assets/1664508/20861146/86253750-b980-11e6-84d2-b9e7eea6eedc.png)
![screenshot-2016-12-03_17 09 44](https://cloud.githubusercontent.com/assets/1664508/20861147/8a5237c4-b980-11e6-98cf-4ee7144ccc73.png)


### After
Using the changes proposed in this PR, the external observation matches the internal state/model:

![screenshot-2016-12-03_17 29 05](https://cloud.githubusercontent.com/assets/1664508/20861140/6cff70c4-b980-11e6-932d-76fe1ce6fccc.png)

![screenshot-2016-12-03_17 29 26](https://cloud.githubusercontent.com/assets/1664508/20861142/7cc7fdaa-b980-11e6-9aad-b078aa6fed5b.png)
