### PR TITLE
description.launch should be launched only once when multimaster is false.

### DIFF
--- a/husky_gazebo/CMakeLists.txt
+++ b/husky_gazebo/CMakeLists.txt
@@ -8,6 +8,6 @@ catkin_package()
 roslaunch_add_file_check(launch)
 
 install(
-  DIRECTORY launch worlds urdf
+  DIRECTORY launch worlds
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/husky_gazebo/launch/spawn_husky.launch
+++ b/husky_gazebo/launch/spawn_husky.launch
@@ -39,14 +39,14 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <group ns="$(arg robot_namespace)">
 
-    <include file="$(find husky_description)/launch/description.launch" >
-      <arg name="robot_namespace" value="$(arg robot_namespace)"/>
-      <arg name="laser_enabled" default="$(arg laser_enabled)"/>
-      <arg name="kinect_enabled" default="$(arg kinect_enabled)"/>
-      <arg name="urdf_extras" default="$(arg urdf_extras)"/>
-    </include>
-
     <group if="$(arg multimaster)">
+      <include file="$(find husky_description)/launch/description.launch" >
+        <arg name="robot_namespace" value="$(arg robot_namespace)"/>
+        <arg name="laser_enabled" default="$(arg laser_enabled)"/>
+        <arg name="kinect_enabled" default="$(arg kinect_enabled)"/>
+        <arg name="urdf_extras" default="$(arg urdf_extras)"/>
+      </include>
+        
       <include file="$(find multimaster_launch)/launch/multimaster_gazebo_robot.launch">
         <arg name="gazebo_interface" value="$(find husky_control)/config/gazebo_interface.yaml" />
         <arg name="robot_namespace" value="$(arg robot_namespace)"/>
@@ -57,9 +57,13 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     </group>
 
     <!-- For single master bringup, run robot control on the gazebo master -->
+    <!-- Note that husky_description/description.launch is already included in husky_control/control.launch. -->
     <group unless="$(arg multimaster)">
       <include file="$(find husky_control)/launch/control.launch">
         <arg name="multimaster" value="$(arg multimaster)"/>
+        <arg name="laser_enabled" value="$(arg laser_enabled)"/>
+        <arg name="kinect_enabled" value="$(arg kinect_enabled)"/>
+        <arg name="urdf_extras" value="$(arg urdf_extras)"/>
       </include>
     </group>
 


### PR DESCRIPTION
This commit fixes #47.

Also delete the urdf subdirectory from the installation list of the package husky_gazebo
since the directory doesn't exist.

HOW BUILT
$ catkin_make_isolated --install --use-ninja

HOW VERIFIED
$ roslaunch husky_gazebo husky_playpen.launch
$ roslaunch husky_viz view_robot.launch

Verify that the LiDAR is present on the gazebo husky and works as expected.

Change-Id: I8797d561489250417dc8fe2b49d958993ca7949c
Signed-off-by: Wei Ren <renwei@smartconn.cc>