### PR TITLE
Add the joint_state_publisher_gui dependency

### DIFF
--- a/husky_viz/package.xml
+++ b/husky_viz/package.xml
@@ -22,6 +22,7 @@
 
   <run_depend>husky_description</run_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>rviz_imu_plugin</run_depend>


### PR DESCRIPTION
The joint_state_publisher's use_gui flag is deprecated, and this package is required in order for the GUI to be present.  Omitting it causes the model to render incorrectly.