### PR TITLE
Depthcamera fix

### DIFF
--- a/husky_bringup/launch/realsense_config/realsense.launch
+++ b/husky_bringup/launch/realsense_config/realsense.launch
@@ -1,0 +1,114 @@
+<launch>
+  <arg name="serial_no"           default=""/>
+  <arg name="usb_port_id"         default=""/>
+  <arg name="device_type"         default=""/>
+  <arg name="json_file_path"      default=""/>
+  <arg name="camera"              default="camera"/>
+  <arg name="tf_prefix"           default="$(arg camera)"/>
+  <arg name="external_manager"    default="false"/>
+  <arg name="manager"             default="realsense2_camera_manager"/>
+  <arg name="base_frame_id"       default="$(optenv JACKAL_REANSENSE_MOUNT front_fender)_realsense" />
+
+  <arg name="fisheye_width"       default="640"/>
+  <arg name="fisheye_height"      default="480"/>
+  <arg name="enable_fisheye"      default="true"/>
+
+  <arg name="depth_width"         default="640"/>
+  <arg name="depth_height"        default="480"/>
+  <arg name="enable_depth"        default="true"/>
+
+  <arg name="infra_width"        default="640"/>
+  <arg name="infra_height"       default="480"/>
+  <arg name="enable_infra1"       default="true"/>
+  <arg name="enable_infra2"       default="true"/>
+
+  <arg name="color_width"         default="640"/>
+  <arg name="color_height"        default="480"/>
+  <arg name="enable_color"        default="true"/>
+
+  <arg name="fisheye_fps"         default="30"/>
+  <arg name="depth_fps"           default="30"/>
+  <arg name="infra_fps"           default="30"/>
+  <arg name="color_fps"           default="30"/>
+  <arg name="gyro_fps"            default="400"/>
+  <arg name="accel_fps"           default="250"/>
+  <arg name="enable_gyro"         default="true"/>
+  <arg name="enable_accel"        default="true"/>
+
+  <arg name="enable_pointcloud"         default="true "/>
+  <arg name="pointcloud_texture_stream" default="RS2_STREAM_COLOR"/>
+  <arg name="pointcloud_texture_index"  default="0"/>
+
+  <arg name="enable_sync"               default="false"/>
+  <arg name="align_depth"               default="false"/>
+
+  <arg name="publish_tf"                default="true"/>
+  <arg name="tf_publish_rate"           default="0"/>
+
+  <arg name="filters"                   default=""/>
+  <arg name="clip_distance"             default="-2"/>
+  <arg name="linear_accel_cov"          default="0.01"/>
+  <arg name="initial_reset"             default="false"/>
+  <arg name="unite_imu_method"          default=""/>
+  <arg name="topic_odom_in"             default="odom_in"/>
+  <arg name="calib_odom_file"           default=""/>
+  <arg name="publish_odom_tf"           default="true"/>
+  <arg name="allow_no_texture_points"   default="false"/>
+
+
+  <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+    <arg name="tf_prefix"                value="$(arg tf_prefix)"/>
+    <arg name="base_frame_id"            value="$(arg base_frame_id)"/>
+    <arg name="external_manager"         value="$(arg external_manager)"/>
+    <arg name="manager"                  value="$(arg manager)"/>
+    <arg name="serial_no"                value="$(arg serial_no)"/>
+    <arg name="usb_port_id"              value="$(arg usb_port_id)"/>
+    <arg name="device_type"              value="$(arg device_type)"/>
+    <arg name="json_file_path"           value="$(arg json_file_path)"/>
+
+    <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>
+    <arg name="pointcloud_texture_stream" value="$(arg pointcloud_texture_stream)"/>
+    <arg name="pointcloud_texture_index"  value="$(arg pointcloud_texture_index)"/>
+    <arg name="enable_sync"              value="$(arg enable_sync)"/>
+    <arg name="align_depth"              value="$(arg align_depth)"/>
+
+    <arg name="fisheye_width"            value="$(arg fisheye_width)"/>
+    <arg name="fisheye_height"           value="$(arg fisheye_height)"/>
+    <arg name="enable_fisheye"           value="$(arg enable_fisheye)"/>
+
+    <arg name="depth_width"              value="$(arg depth_width)"/>
+    <arg name="depth_height"             value="$(arg depth_height)"/>
+    <arg name="enable_depth"             value="$(arg enable_depth)"/>
+
+    <arg name="color_width"              value="$(arg color_width)"/>
+    <arg name="color_height"             value="$(arg color_height)"/>
+    <arg name="enable_color"             value="$(arg enable_color)"/>
+
+    <arg name="infra_width"              value="$(arg infra_width)"/>
+    <arg name="infra_height"             value="$(arg infra_height)"/>
+    <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
+    <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
+
+    <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
+    <arg name="depth_fps"                value="$(arg depth_fps)"/>
+    <arg name="infra_fps"                value="$(arg infra_fps)"/>
+    <arg name="color_fps"                value="$(arg color_fps)"/>
+    <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
+    <arg name="accel_fps"                value="$(arg accel_fps)"/>
+    <arg name="enable_gyro"              value="$(arg enable_gyro)"/>
+    <arg name="enable_accel"             value="$(arg enable_accel)"/>
+
+    <arg name="publish_tf"               value="$(arg publish_tf)"/>
+    <arg name="tf_publish_rate"          value="$(arg tf_publish_rate)"/>
+
+    <arg name="filters"                  value="$(arg filters)"/>
+    <arg name="clip_distance"            value="$(arg clip_distance)"/>
+    <arg name="linear_accel_cov"         value="$(arg linear_accel_cov)"/>
+    <arg name="initial_reset"            value="$(arg initial_reset)"/>
+    <arg name="unite_imu_method"         value="$(arg unite_imu_method)"/>
+    <arg name="topic_odom_in"            value="$(arg topic_odom_in)"/>
+    <arg name="calib_odom_file"          value="$(arg calib_odom_file)"/>
+    <arg name="publish_odom_tf"          value="$(arg publish_odom_tf)"/>
+    <arg name="allow_no_texture_points"  value="$(arg allow_no_texture_points)"/>
+  </include>
+</launch>

--- a/husky_bringup/launch/realsense_config/realsense.launch
+++ b/husky_bringup/launch/realsense_config/realsense.launch
@@ -7,7 +7,7 @@
   <arg name="tf_prefix"           default="$(arg camera)"/>
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
-  <arg name="base_frame_id"       default="$(optenv JACKAL_REANSENSE_MOUNT front_fender)_realsense" />
+  <arg name="base_frame_id"       default="sensor_arch_mount_link" />
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -111,4 +111,32 @@
     <arg name="publish_odom_tf"          value="$(arg publish_odom_tf)"/>
     <arg name="allow_no_texture_points"  value="$(arg allow_no_texture_points)"/>
   </include>
+
+  <!-- Include poincloud_to_laserscan if realsense is attached -->
+  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="realsense_to_laserscan" output="screen">
+
+      <remap from="cloud_in" to="realsense/depth/color/points"/>
+      <remap from="scan" to="realsense/scan"/>
+      <!-- TODO: modify these to match the Realsense D400 series parameters -->
+      <rosparam>
+          target_frame: base_link # Leave empty to output scan in the pointcloud frame
+          tolerance: 1.0
+          min_height: 0.05
+          max_height: 1.0
+
+          angle_min: -0.7592182246175333 # -(87/2))*M_PI/180.0
+          angle_max: 0.7592182246175333 # (87/2))*M_PI/180.0
+          angle_increment: 0.005 # M_PI/360.0
+          scan_time: 0.3333
+          range_min: 0.105
+          range_max: 8.0
+          use_inf: true
+
+          # Concurrency level, affects number of pointclouds queued for processing and number of threads used
+          # 0 : Detect number of cores
+          # 1 : Single threaded
+          # 2->inf : Parallelism level
+          concurrency_level: 1
+      </rosparam>
+  </node>
 </launch>

--- a/husky_bringup/launch/realsense_config/realsense.launch
+++ b/husky_bringup/launch/realsense_config/realsense.launch
@@ -3,11 +3,10 @@
   <arg name="usb_port_id"         default=""/>
   <arg name="device_type"         default=""/>
   <arg name="json_file_path"      default=""/>
-  <arg name="camera"              default="camera"/>
-  <arg name="tf_prefix"           default="$(arg camera)"/>
+  <arg name="tf_prefix"           default="$(optenv HUSKY_REALSENSE_TF_PREFIX camera)"/>
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
-  <arg name="base_frame_id"       default="sensor_arch_mount_link" />
+  <arg name="base_frame_id"       default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME sensor_arch_mount_link)" />
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>

--- a/husky_bringup/package.xml
+++ b/husky_bringup/package.xml
@@ -32,13 +32,13 @@
   <run_depend>nmea_comms</run_depend>
   <run_depend>nmea_navsat_driver</run_depend>
   <run_depend>python-scipy</run_depend>
+  <run_depend>realsense2_camera</run_depend>
   <run_depend>robot_localization</run_depend>
   <run_depend>robot_upstart</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>um6</run_depend>
   <run_depend>um7</run_depend>
-  <run_depend>realsense2_camera</run_depend>
 
   <export>
   </export>

--- a/husky_bringup/package.xml
+++ b/husky_bringup/package.xml
@@ -38,6 +38,7 @@
   <run_depend>tf2_ros</run_depend>
   <run_depend>um6</run_depend>
   <run_depend>um7</run_depend>
+  <run_depend>realsense2_camera</run_depend>
 
   <export>
   </export>

--- a/husky_control/launch/control.launch
+++ b/husky_control/launch/control.launch
@@ -10,6 +10,7 @@
 
   <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
   <arg name="kinect_enabled" default="$(optenv HUSKY_KINECT_ENABLED false)"/>
+  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED false)"/>
   <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
 
   <include file="$(find multimaster_launch)/launch/multimaster_robot.launch" if="$(arg multimaster)">
@@ -23,6 +24,7 @@
   <include file="$(find husky_description)/launch/description.launch" >
     <arg name="laser_enabled" default="$(arg laser_enabled)"/>
     <arg name="kinect_enabled" default="$(arg kinect_enabled)"/>
+    <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
     <arg name="urdf_extras" default="$(arg urdf_extras)"/>
   </include>
 

--- a/husky_description/launch/description.launch
+++ b/husky_description/launch/description.launch
@@ -28,6 +28,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <arg name="robot_namespace" default="/"/>
   <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
   <arg name="kinect_enabled" default="$(optenv HUSKY_KINECT_ENABLED false)"/>
+  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED false)"/>
   <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
 
   <param name="robot_description" command="$(find xacro)/xacro '$(find husky_description)/urdf/husky.urdf.xacro'
@@ -35,6 +36,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     robot_namespace:=$(arg robot_namespace)
     laser_enabled:=$(arg laser_enabled)
     kinect_enabled:=$(arg kinect_enabled)
+    realsense_enabled:=$(arg realsense_enabled)
     urdf_extras:=$(arg urdf_extras)
     " />
 

--- a/husky_description/package.xml
+++ b/husky_description/package.xml
@@ -21,6 +21,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
+  <run_depend>realsense2_description</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>lms1xx</run_depend>

--- a/husky_description/urdf/accessories/intel_realsense.urdf.xacro
+++ b/husky_description/urdf/accessories/intel_realsense.urdf.xacro
@@ -76,10 +76,14 @@
 
     <link name="${prefix}_realsense_lens">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <!--
+          the model's origin is in the middle & it's rotated to lie in
+          the optical standard with X left, Y up, and Z forward
+        -->
+        <origin xyz="0.0115 0 0.0100" rpy="1.570796 0 1.570796" />
         <geometry>
           <!-- Origin of this mesh is the base of the bracket. -->
-          <mesh filename="package://husky_description/meshes/accessories/intel_realsense_d415.stl" />
+          <mesh filename="package://realsense2_description/meshes/d415.stl" />
         </geometry>
         <material name="white" />
       </visual>

--- a/husky_description/urdf/accessories/intel_realsense.urdf.xacro
+++ b/husky_description/urdf/accessories/intel_realsense.urdf.xacro
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="intel_realsense_mount" params="prefix topic parent_link">
+
+    <xacro:macro name="intel_realsense" params="
+               frame:=realsense          topic:=realsense
+               h_fov:=1.5184351666666667 v_fov:=1.0122901111111111
+               min_range:=0.105          max_range:=8.0
+               width:=640                height:=480
+               update_rate:=30
+               robot_namespace:=/">
+
+      <!-- this link is the origin for the camera's data -->
+      <link name="${frame}" />
+
+      <!--
+        The gazebo plugin aligns the depth data with the Z axis, with X=left and Y=up
+        ROS expects the depth data along the X axis, with Y=left and Z=up
+        This link only exists to give the gazebo plugin the correctly-oriented frame
+      -->
+      <link name="${frame}_gazebo" />
+      <joint name="${frame}_gazebo_joint" type="fixed">
+        <parent link="${frame}"/>
+        <child link="${frame}_gazebo"/>
+        <origin xyz="0.0 0 0" rpy="-1.5707963267948966 0 -1.5707963267948966"/>
+      </joint>
+
+      <gazebo reference="${frame}">
+        <turnGravityOff>true</turnGravityOff>
+        <sensor type="depth" name="${prefix}_realsense_depth">
+          <update_rate>${update_rate}</update_rate>
+          <camera>
+            <!-- 75x65 degree FOV for the depth sensor -->
+            <horizontal_fov>${h_fov}</horizontal_fov>
+            <vertical_fov>${v_fov}</vertical_fov>
+
+            <image>
+              <width>${width}</width>
+              <height>${height}</height>
+              <!-- TODO: check what format the Realsense hardware delivers and set this to match! -->
+              <format>RGB8</format>
+            </image>
+            <clip>
+              <!-- give the color sensor a maximum range of 50m so that the simulation renders nicely -->
+              <near>0.01</near>
+              <far>50.0</far>
+            </clip>
+          </camera>
+          <plugin name="kinect_controller" filename="libgazebo_ros_openni_kinect.so">
+            <baseline>0.2</baseline>
+            <alwaysOn>true</alwaysOn>
+            <updateRate>${update_rate}</updateRate>
+            <cameraName>${topic}</cameraName>
+            <imageTopicName>color/image_raw</imageTopicName>
+            <cameraInfoTopicName>color/camera_info</cameraInfoTopicName>
+            <depthImageTopicName>depth/image_rect_raw</depthImageTopicName>
+            <depthImageInfoTopicName>depth/camera_info</depthImageInfoTopicName>
+            <pointCloudTopicName>depth/color/points</pointCloudTopicName>
+            <frameName>${frame}_gazebo</frameName>
+            <pointCloudCutoff>${min_range}</pointCloudCutoff>
+            <pointCloudCutoffMax>${max_range}</pointCloudCutoffMax>
+            <distortionK1>0.00000001</distortionK1>
+            <distortionK2>0.00000001</distortionK2>
+            <distortionK3>0.00000001</distortionK3>
+            <distortionT1>0.00000001</distortionT1>
+            <distortionT2>0.00000001</distortionT2>
+            <CxPrime>0</CxPrime>
+            <Cx>0</Cx>
+            <Cy>0</Cy>
+            <focalLength>0</focalLength>
+            <hackBaseline>0</hackBaseline>
+          </plugin>
+        </sensor>
+      </gazebo>
+    </xacro:macro>
+
+    <link name="${prefix}_realsense_lens">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <!-- Origin of this mesh is the base of the bracket. -->
+          <mesh filename="package://husky_description/meshes/accessories/intel_realsense_d415.stl" />
+        </geometry>
+        <material name="white" />
+      </visual>
+    </link>
+
+    <joint type="fixed" name="${prefix}_realsense_lens_joint">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${parent_link}" />
+      <child link="${prefix}_realsense_lens" />
+    </joint>
+    <joint type="fixed" name="${prefix}_realsense_joint">
+      <origin xyz="0.025 0 0" rpy="0 0 0" />
+      <parent link="${prefix}_realsense_lens" />
+      <child link="${prefix}_realsense" />
+    </joint>
+
+    <xacro:intel_realsense frame="${prefix}_realsense" topic="${topic}"/>
+  </xacro:macro>
+</robot>

--- a/husky_description/urdf/accessories/kinect_camera.urdf.xacro
+++ b/husky_description/urdf/accessories/kinect_camera.urdf.xacro
@@ -56,6 +56,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <link name="${prefix}_frame_optical"/>
 
     <gazebo reference="${prefix}_link">
+      <selfCollide>true</selfCollide>
+      <turnGravityOff>true</turnGravityOff>
       <sensor type="depth" name="${prefix}">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>

--- a/husky_description/urdf/decorations.urdf.xacro
+++ b/husky_description/urdf/decorations.urdf.xacro
@@ -25,6 +25,14 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <robot name="husky_decorations" xmlns:xacro="http://ros.org/wiki/xacro">
 
+  <material name="dark_grey"><color rgba="0.2 0.2 0.2 1.0" /></material>
+  <material name="medium_grey"><color rgba="0.6 0.6 0.6 1.0" /></material>
+  <material name="light_grey"><color rgba="0.8 0.8 0.8 1.0" /></material>
+  <material name="yellow"><color rgba="0.8 0.8 0.0 1.0" /></material>
+  <material name="black"><color rgba="0.15 0.15 0.15 1.0" /></material>
+  <material name="white"><color rgba="1.0 1.0 1.0 1.0" /></material>
+  <material name="red"><color rgba="1.0 0.0 0.0 1.0" /></material>
+
   <xacro:macro name="husky_decorate">
 
     <xacro:property name="husky_front_bumper_extend" value="$(optenv HUSKY_FRONT_BUMPER_EXTEND 0)" />

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -33,6 +33,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="kinect_xyz" default="$(optenv HUSKY_KINECT_XYZ 0 0 0)" />
   <xacro:arg name="kinect_rpy" default="$(optenv HUSKY_KINECT_RPY 0 0.18 3.14)" />
 
+  <xacro:arg name="realsense_enabled" default="false" />
+  <xacro:arg name="realsense_xyz" default="$(optenv HUSKY_REALSENSE_XYZ 0 0 0)" />
+  <xacro:arg name="realsense_rpy" default="$(optenv HUSKY_REALSENSE_RPY 0 0 0)" />
+
   <xacro:property name="husky_front_bumper_extend" value="$(optenv HUSKY_FRONT_BUMPER_EXTEND 0)" />
   <xacro:property name="husky_rear_bumper_extend" value="$(optenv HUSKY_REAR_BUMPER_EXTEND 0)" />
 
@@ -44,6 +48,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:include filename="$(find husky_description)/urdf/wheel.urdf.xacro" />
 
   <xacro:include filename="$(find husky_description)/urdf/accessories/kinect_camera.urdf.xacro"/>
+  <xacro:include filename="$(find husky_description)/urdf/accessories/intel_realsense.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sensor_arch.urdf.xacro"/>
 
@@ -151,7 +156,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </xacro:if>
 
   <xacro:if value="$(arg kinect_enabled)">
-
     <xacro:sensor_arch prefix="" parent="top_plate_link">
       <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14"/>
     </xacro:sensor_arch>
@@ -160,8 +164,14 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       <parent link="sensor_arch_mount_link"/>
       <child link="camera_link"/>
     </joint>
-
     <xacro:kinect_camera prefix="camera" robot_namespace="$(arg robot_namespace)"/>
+  </xacro:if>
+
+  <xacro:if value="$(arg realsense_enabled)">
+    <xacro:sensor_arch prefix="" parent="top_plate_link">
+      <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14"/>
+    </xacro:sensor_arch>
+    <xacro:intel_realsense_mount prefix="camera" topic="realsense" parent_link="sensor_arch_mount_link"/>
   </xacro:if>
 
   <gazebo>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -36,6 +36,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="realsense_enabled" default="false" />
   <xacro:arg name="realsense_xyz" default="$(optenv HUSKY_REALSENSE_XYZ 0 0 0)" />
   <xacro:arg name="realsense_rpy" default="$(optenv HUSKY_REALSENSE_RPY 0 0 0)" />
+  <xacro:arg name="realsense_mount" default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME sensor_arch_mount_link)" />
 
   <xacro:property name="husky_front_bumper_extend" value="$(optenv HUSKY_FRONT_BUMPER_EXTEND 0)" />
   <xacro:property name="husky_rear_bumper_extend" value="$(optenv HUSKY_REAR_BUMPER_EXTEND 0)" />
@@ -180,7 +181,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <link name="realsense_mountpoint"/>
     <joint name="realsense_mountpoint_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 -3.14159" />
-      <parent link="sensor_arch_mount_link"/>
+      <parent link="$(arg realsense_mount)"/>
       <child link="realsense_mountpoint" />
     </joint>
     <xacro:intel_realsense_mount prefix="camera" topic="realsense" parent_link="realsense_mountpoint"/>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -155,10 +155,18 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   </xacro:if>
 
-  <xacro:if value="$(arg kinect_enabled)">
+  <!-- top sensor arch; include this if we have either the kinect or realsense enabled -->
+  <xacro:property name="topbar_needed_kinect" value="$(arg kinect_enabled)" />
+  <xacro:property name="topbar_needed_realsense" value="$(arg realsense_enabled)" />
+  <xacro:if value="${topbar_needed_kinect.lower() == 'true' or topbar_needed_kinect == '1' or topbar_needed_realsense == 'true' or topbar_needed_realsense == '1'}">
     <xacro:sensor_arch prefix="" parent="top_plate_link">
       <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14"/>
     </xacro:sensor_arch>
+  </xacro:if>
+
+  <!-- add the kinect for xbox 360 to the topbar if needed -->
+  <!-- NOTE: this camera is considered depricated -->
+  <xacro:if value="$(arg kinect_enabled)">
     <joint name="kinect_frame_joint" type="fixed">
       <origin xyz="$(arg kinect_xyz)" rpy="$(arg kinect_rpy)" />
       <parent link="sensor_arch_mount_link"/>
@@ -167,10 +175,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <xacro:kinect_camera prefix="camera" robot_namespace="$(arg robot_namespace)"/>
   </xacro:if>
 
+  <!-- add the intel realsense to the topbar if needed -->
   <xacro:if value="$(arg realsense_enabled)">
-    <xacro:sensor_arch prefix="" parent="top_plate_link">
-      <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14159"/>
-    </xacro:sensor_arch>
     <link name="realsense_mountpoint"/>
     <joint name="realsense_mountpoint_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 -3.14159" />

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -169,9 +169,15 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <xacro:if value="$(arg realsense_enabled)">
     <xacro:sensor_arch prefix="" parent="top_plate_link">
-      <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14"/>
+      <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14159"/>
     </xacro:sensor_arch>
-    <xacro:intel_realsense_mount prefix="camera" topic="realsense" parent_link="sensor_arch_mount_link"/>
+    <link name="realsense_mountpoint"/>
+    <joint name="realsense_mountpoint_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 -3.14159" />
+      <parent link="sensor_arch_mount_link"/>
+      <child link="realsense_mountpoint" />
+    </joint>
+    <xacro:intel_realsense_mount prefix="camera" topic="realsense" parent_link="realsense_mountpoint"/>
   </xacro:if>
 
   <gazebo>

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -29,6 +29,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="laser_enabled" default="true"/>
   <arg name="kinect_enabled" default="false"/>
+  <arg name="realsense_enabled" default="false"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(arg world_name)"/> <!-- world_name is wrt GAZEBO_RESOURCE_PATH environment variable -->
@@ -42,6 +43,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
     <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="kinect_enabled" value="$(arg kinect_enabled)"/>
+    <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>
 
 </launch>

--- a/husky_gazebo/launch/husky_playpen.launch
+++ b/husky_gazebo/launch/husky_playpen.launch
@@ -27,12 +27,14 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="laser_enabled" default="true"/>
   <arg name="kinect_enabled" default="false"/>
+  <arg name="realsense_enabled" default="false"/>
 
   <include file="$(find husky_gazebo)/launch/playpen.launch" />
 
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
     <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="kinect_enabled" value="$(arg kinect_enabled)"/>
+    <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>
 
 </launch>

--- a/husky_gazebo/launch/kinect.launch
+++ b/husky_gazebo/launch/kinect.launch
@@ -1,0 +1,28 @@
+<launch deprecated="The Kinect camera is discontinued.  The kinect_enabled flag may be removed in a future release of Husky. Please consider using realsense_enabled instead.">
+  <!-- Include poincloud_to_laserscan if simulated Kinect is attached -->
+  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan" output="screen">
+
+      <remap from="cloud_in" to="camera/depth/points"/>
+      <remap from="scan" to="kinect/scan"/>
+      <rosparam>
+          target_frame: base_link # Leave empty to output scan in the pointcloud frame
+          tolerance: 1.0
+          min_height: 0.05
+          max_height: 1.0
+
+          angle_min: -0.52 # -30.0*M_PI/180.0
+          angle_max: 0.52 # 30.0*M_PI/180.0
+          angle_increment: 0.005 # M_PI/360.0
+          scan_time: 0.3333
+          range_min: 0.45
+          range_max: 4.0
+          use_inf: true
+
+          # Concurrency level, affects number of pointclouds queued for processing and number of threads used
+          # 0 : Detect number of cores
+          # 1 : Single threaded
+          # 2->inf : Parallelism level
+          concurrency_level: 1
+      </rosparam>
+  </node>
+</launch>

--- a/husky_gazebo/launch/realsense.launch
+++ b/husky_gazebo/launch/realsense.launch
@@ -1,8 +1,8 @@
 <launch>
   <!-- Include poincloud_to_laserscan if simulated realsense is attached -->
-  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan" output="screen">
+  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="realsense_to_laserscan" output="screen">
 
-      <remap from="cloud_in" to="camera/depth/points"/>
+      <remap from="cloud_in" to="realsense/depth/color/points"/>
       <remap from="scan" to="realsense/scan"/>
       <!-- TODO: modify these to match the Realsense D400 series parameters -->
       <rosparam>
@@ -11,12 +11,12 @@
           min_height: 0.05
           max_height: 1.0
 
-          angle_min: -0.52 # -30.0*M_PI/180.0
-          angle_max: 0.52 # 30.0*M_PI/180.0
+          angle_min: -0.7592182246175333 # -(87/2))*M_PI/180.0
+          angle_max: 0.7592182246175333 # (87/2))*M_PI/180.0
           angle_increment: 0.005 # M_PI/360.0
           scan_time: 0.3333
-          range_min: 0.45
-          range_max: 4.0
+          range_min: 0.105
+          range_max: 8.0
           use_inf: true
 
           # Concurrency level, affects number of pointclouds queued for processing and number of threads used

--- a/husky_gazebo/launch/realsense.launch
+++ b/husky_gazebo/launch/realsense.launch
@@ -1,0 +1,29 @@
+<launch>
+  <!-- Include poincloud_to_laserscan if simulated realsense is attached -->
+  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan" output="screen">
+
+      <remap from="cloud_in" to="camera/depth/points"/>
+      <remap from="scan" to="realsense/scan"/>
+      <!-- TODO: modify these to match the Realsense D400 series parameters -->
+      <rosparam>
+          target_frame: base_link # Leave empty to output scan in the pointcloud frame
+          tolerance: 1.0
+          min_height: 0.05
+          max_height: 1.0
+
+          angle_min: -0.52 # -30.0*M_PI/180.0
+          angle_max: 0.52 # 30.0*M_PI/180.0
+          angle_increment: 0.005 # M_PI/360.0
+          scan_time: 0.3333
+          range_min: 0.45
+          range_max: 4.0
+          use_inf: true
+
+          # Concurrency level, affects number of pointclouds queued for processing and number of threads used
+          # 0 : Detect number of cores
+          # 1 : Single threaded
+          # 2->inf : Parallelism level
+          concurrency_level: 1
+      </rosparam>
+  </node>
+</launch>

--- a/husky_gazebo/launch/spawn_husky.launch
+++ b/husky_gazebo/launch/spawn_husky.launch
@@ -47,7 +47,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <arg name="kinect_enabled" default="$(arg kinect_enabled)"/>
         <arg name="urdf_extras" default="$(arg urdf_extras)"/>
       </include>
-        
+
       <include file="$(find multimaster_launch)/launch/multimaster_gazebo_robot.launch">
         <arg name="gazebo_interface" value="$(find husky_control)/config/gazebo_interface.yaml" />
         <arg name="robot_namespace" value="$(arg robot_namespace)"/>
@@ -68,35 +68,12 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       </include>
     </group>
 
+    <!-- Additional nodes for specific accessories -->
     <group if="$(arg kinect_enabled)">
-
-      <!-- Include poincloud_to_laserscan if simulated Kinect is attached -->
-      <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan" output="screen">
-
-          <remap from="cloud_in" to="camera/depth/points"/>
-          <remap from="scan" to="scan"/>
-          <rosparam>
-              target_frame: base_link # Leave empty to output scan in the pointcloud frame
-              tolerance: 1.0
-              min_height: 0.05
-              max_height: 1.0
-
-              angle_min: -0.52 # -30.0*M_PI/180.0
-              angle_max: 0.52 # 30.0*M_PI/180.0
-              angle_increment: 0.005 # M_PI/360.0
-              scan_time: 0.3333
-              range_min: 0.45
-              range_max: 4.0
-              use_inf: true
-
-              # Concurrency level, affects number of pointclouds queued for processing and number of threads used
-              # 0 : Detect number of cores
-              # 1 : Single threaded
-              # 2->inf : Parallelism level
-              concurrency_level: 1
-          </rosparam>
-      </node>
-
+      <include file="$(find husky_gazebo)/launch/kinect.launch" />
+    </group>
+    <group if="$(arg realsense_enabled)">
+      <include file="$(find husky_gazebo)/launch/realsense.launch" />
     </group>
 
     <!-- Spawn robot in gazebo -->

--- a/husky_gazebo/launch/spawn_husky.launch
+++ b/husky_gazebo/launch/spawn_husky.launch
@@ -35,7 +35,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <arg name="yaw" default="0.0"/>
 
   <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
-  <arg name="kinect_enabled" default="$(optenv HUSKY_UR5_ENABLED false)"/>
+  <arg name="kinect_enabled" default="$(optenv HUSKY_KINECT_ENABLED false)"/>
+  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED false)"/>
   <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
 
   <group ns="$(arg robot_namespace)">
@@ -45,6 +46,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <arg name="robot_namespace" value="$(arg robot_namespace)"/>
         <arg name="laser_enabled" default="$(arg laser_enabled)"/>
         <arg name="kinect_enabled" default="$(arg kinect_enabled)"/>
+        <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
         <arg name="urdf_extras" default="$(arg urdf_extras)"/>
       </include>
 
@@ -64,6 +66,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <arg name="multimaster" value="$(arg multimaster)"/>
         <arg name="laser_enabled" value="$(arg laser_enabled)"/>
         <arg name="kinect_enabled" value="$(arg kinect_enabled)"/>
+        <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
         <arg name="urdf_extras" value="$(arg urdf_extras)"/>
       </include>
     </group>

--- a/husky_gazebo/worlds/clearpath_playpen.world
+++ b/husky_gazebo/worlds/clearpath_playpen.world
@@ -10,7 +10,7 @@ Redistribution and use in source and binary forms, with or without modification,
 the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions and the
    following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
    following disclaimer in the documentation and/or other materials provided with the distribution.
  * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
    products derived from this software without specific prior written permission.

--- a/husky_viz/launch/view_model.launch
+++ b/husky_viz/launch/view_model.launch
@@ -3,11 +3,13 @@
 
   <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
   <arg name="kinect_enabled" default="false"/>
+  <arg name="realsense_enabled" default="false"/>
 
   <!-- Standalone launcher to visualize the robot model. -->
   <include file="$(find husky_description)/launch/description.launch">
     <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="kinect_enabled" value="$(arg kinect_enabled)"/>
+    <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>
 
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />


### PR DESCRIPTION
Lots of things going on here:
- Move the kinect's pointcloud_to_laserscan node into a separate launch file so that we can mark it as deprecated (the deprecated attribute only works in <launch> tags)
- Add support for the Intel Realsense to husky_gazebo, husky_description, husky_viz, and husky_bringup
- Modify the Husky's URDF so that the top sensor bar gets added if either the RealSense or Kinect is present
- Add an additional pointcloud_to_laserscan node so the Realsense can be used as a fake lidar
- Remove the one instance of the HUSKY_UR5_ENABLED variable from controlling whether the Kinect is enabled; everywhere else we use HUSKY_KINECT_ENABLED; not sure why we had one instance where it was different (UR5 doesn't get used anywhere else in the repo that I could see)