### PR TITLE
Fix a bug in the UM7 and UM6 launch files

### DIFF
--- a/husky_bringup/launch/um6_config/um6.launch
+++ b/husky_bringup/launch/um6_config/um6.launch
@@ -22,7 +22,7 @@
 
   <!-- Filter raw gyro, accel and mag data into a usable orientation -->
   <node pkg="nodelet" type="nodelet" name="imu_filter" args="load imu_filter_madgwick/ImuFilterNodelet imu_manager">
-    <rosparam file="$(optenv HUSKY_MAG_CONFIG config/mag_config_default.yaml)" />
+    <rosparam file="$(eval optenv('HUSKY_MAG_CONFIG', find('husky_bringup')+'/config/mag_config_default.yaml'))" />
     <rosparam>
       orientation_stddev: 0.001
       gain: 0.01

--- a/husky_bringup/launch/um7_config/um7.launch
+++ b/husky_bringup/launch/um7_config/um7.launch
@@ -22,7 +22,7 @@
 
   <!-- Filter raw gyro, accel and mag data into a usable orientation -->
   <node pkg="nodelet" type="nodelet" name="imu_filter" args="load imu_filter_madgwick/ImuFilterNodelet imu_manager">
-    <rosparam file="$(optenv HUSKY_MAG_CONFIG config/mag_config_default.yaml)" />
+    <rosparam file="$(eval optenv('HUSKY_MAG_CONFIG', find('husky_bringup')+'/config/mag_config_default.yaml'))" />
     <rosparam>
       orientation_stddev: 0.001
       gain: 0.01


### PR DESCRIPTION
When these files are installed to ros.d as part of a bringup they fail to find the mag config file unless HUSKY_MAG_CONFIG is set to the full path to the file.

Kinetic introduced the $(eval ...) substitution arg which lets us nest parameters, so let's use that to find the full path to the default config file.