### PR TITLE
Fix melodic frontier exploration

### DIFF
--- a/husky_navigation/config/costmap_exploration.yaml
+++ b/husky_navigation/config/costmap_exploration.yaml
@@ -4,7 +4,7 @@ rolling_window: false
 
 plugins: 
 - {name: external,            type: "costmap_2d::StaticLayer"}
-- {name: explore_boundary,    type: "frontier_exploration::BoundedExploreLayer"}
+- {name: polygon_layer,       type: "polygon_layer::PolygonLayer"}
 #Can disable sensor layer if gmapping is fast enough to update scans
 - {name: obstacles_laser,     type: "costmap_2d::ObstacleLayer"}
 - {name: inflation,           type: "costmap_2d::InflationLayer"}

--- a/husky_navigation/launch/exploration.launch
+++ b/husky_navigation/launch/exploration.launch
@@ -25,18 +25,23 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <!-- <node pkg="frontier_exploration" type="explore_client" name="explore_client" output="screen"/>
+  <arg name="plugin" default="frontier_exploration::FrontierPlugin"/>
+  <param name="plugin_name" value="$(arg plugin)"/>
+  <!-- <arg name="blacklist_box_size" default="0.5"/>
+  <param name="blacklist_box_size" value="$(arg blacklist_box_size)"/> -->
 
-  <node pkg="frontier_exploration" type="explore_server" name="explore_server" output="screen">
+ <node pkg="exploration_server" type="plugin_client" name="explore_client" output="screen"  />
 
-    <param name="frequency" value="1.0"/> -->
+  <node pkg="exploration_server" type="exploration_server_node" name="explore_server" output="screen"  >
+  
+    <!-- <param name="frequency" value="1.0"/> --> 
 
     <!-- Should be less than sensor range -->
-    <!-- <param name="goal_aliasing" value="2.0"/>
+    <!-- <param name="goal_aliasing" value="2.0"/> -->
 
     <rosparam file="$(find husky_navigation)/config/costmap_common.yaml" command="load" ns="explore_costmap" />
     <rosparam file="$(find husky_navigation)/config/costmap_exploration.yaml" command="load" ns="explore_costmap" />
 
-  </node> -->
+  </node>
 
 </launch>

--- a/husky_navigation/launch/exploration.launch
+++ b/husky_navigation/launch/exploration.launch
@@ -27,17 +27,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="plugin" default="frontier_exploration::FrontierPlugin"/>
   <param name="plugin_name" value="$(arg plugin)"/>
-  <!-- <arg name="blacklist_box_size" default="0.5"/>
-  <param name="blacklist_box_size" value="$(arg blacklist_box_size)"/> -->
 
- <node pkg="exploration_server" type="plugin_client" name="explore_client" output="screen"  />
+  <node pkg="exploration_server" type="plugin_client" name="explore_client" output="screen" />
 
-  <node pkg="exploration_server" type="exploration_server_node" name="explore_server" output="screen"  >
-  
-    <!-- <param name="frequency" value="1.0"/> --> 
-
-    <!-- Should be less than sensor range -->
-    <!-- <param name="goal_aliasing" value="2.0"/> -->
+  <node pkg="exploration_server" type="exploration_server_node" name="explore_server" output="screen">
 
     <rosparam file="$(find husky_navigation)/config/costmap_common.yaml" command="load" ns="explore_costmap" />
     <rosparam file="$(find husky_navigation)/config/costmap_exploration.yaml" command="load" ns="explore_costmap" />

--- a/husky_navigation/launch/exploration.launch
+++ b/husky_navigation/launch/exploration.launch
@@ -28,13 +28,13 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <arg name="plugin" default="frontier_exploration::FrontierPlugin"/>
   <param name="plugin_name" value="$(arg plugin)"/>
 
-  <node pkg="exploration_server" type="plugin_client" name="explore_client" output="screen" />
+  <!-- <node pkg="exploration_server" type="plugin_client" name="explore_client" output="screen" /> -->
 
-  <node pkg="exploration_server" type="exploration_server_node" name="explore_server" output="screen">
+  <!-- <node pkg="exploration_server" type="exploration_server_node" name="explore_server" output="screen">
 
     <rosparam file="$(find husky_navigation)/config/costmap_common.yaml" command="load" ns="explore_costmap" />
     <rosparam file="$(find husky_navigation)/config/costmap_exploration.yaml" command="load" ns="explore_costmap" />
 
-  </node>
+  </node> -->
 
 </launch>

--- a/husky_navigation/launch/exploration_demo.launch
+++ b/husky_navigation/launch/exploration_demo.launch
@@ -32,6 +32,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <include file="$(find husky_navigation)/launch/move_base.launch" />
 
   <!-- Run Frontier Exploration -->
-  <!-- <include file="$(find husky_navigation)/launch/exploration.launch" /> -->
+  <include file="$(find husky_navigation)/launch/exploration.launch" />
 
 </launch>

--- a/husky_navigation/launch/exploration_demo.launch
+++ b/husky_navigation/launch/exploration_demo.launch
@@ -32,6 +32,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <include file="$(find husky_navigation)/launch/move_base.launch" />
 
   <!-- Run Frontier Exploration -->
-  <include file="$(find husky_navigation)/launch/exploration.launch" />
+  <!-- <include file="$(find husky_navigation)/launch/exploration.launch" /> -->
 
 </launch>


### PR DESCRIPTION
Fixing frontier exploration in melodic, reflecting the changes in cost map plugin name at https://github.com/paulbovbel/frontier_exploration/issues/45

Using the correct frontier_exploration::FrontierPlugin rather than the default exploration_server::ExamplePlugin.

Note that in robot.rviz, change  "**Fixed Frame**" to **map** for assigning correct frame to the clicked points.

For installing the frontier_exploration package, see https://github.com/paulbovbel/frontier_exploration/issues/49  and https://github.com/husky/husky/pull/143