### PR TITLE
Add VLP16, secondary LMS1xx support

### DIFF
--- a/husky_bringup/launch/lms1xx_config/lms1xx.launch
+++ b/husky_bringup/launch/lms1xx_config/lms1xx.launch
@@ -1,10 +1,17 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="lms1xx_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)" />
+  <arg name="lms1xx_secondary_enabled" default="$(optenv HUSKY_LMS1XX_SECONDARY_ENABLED false)" />
   <group if="$(arg lms1xx_enabled)">
     <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
       <param name="host" value="$(env HUSKY_LMS1XX_IP)" />
       <param name="frame_id" value="base_laser" />
+    </node>
+  </group>
+  <group if="$(arg lms1xx_secondary_enabled)">
+    <node pkg="lms1xx" name="lms1xx_secondary" type="LMS1xx_node">
+      <param name="host" value="$(env HUSKY_LMS1XX_SECONDARY_IP)" />
+      <param name="frame_id" value="rear_laser" />
     </node>
   </group>
 </launch>

--- a/husky_bringup/launch/velodyne_config/vlp16.launch
+++ b/husky_bringup/launch/velodyne_config/vlp16.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="laser_3d_enabled" default="$(optenv HUSKY_LASER_3D_ENABLED false)" />
+  <group if="$(arg laser_3d_enabled)">
+    <include file="$(find velodyne_pointcloud)/launch/VLP-16.launch">
+      <arg name="device_ip" value="$(optenv HUSKY_LASER_3D_HOST 192.168.131.20)" />
+      <remap from="velodyne_points" to="$(optenv HUSKY_LASER_3D_TOPIC points)" />
+    </include>
+  </group>
+</launch>

--- a/husky_bringup/package.xml
+++ b/husky_bringup/package.xml
@@ -38,6 +38,7 @@
   <run_depend>tf2_ros</run_depend>
   <run_depend>um6</run_depend>
   <run_depend>um7</run_depend>
+  <run_depend>velodyne_pointcloud</run_depend>
 
   <export>
   </export>

--- a/husky_bringup/scripts/install
+++ b/husky_bringup/scripts/install
@@ -23,7 +23,10 @@ if os.path.exists('/dev/microstrain_gx5'):
 if os.path.exists('/dev/clearpath/gps'):
   j.add(package="husky_bringup", glob="launch/navsat_config/*")
 
-if os.environ.get('HUSKY_LMS1XX_IP'):
+if os.environ.get('HUSKY_LMS1XX_IP') or os.environ.get('HUSKY_LMS1XX_SECONDARY_IP'):
   j.add(package="husky_bringup", glob="launch/lms1xx_config/*")
+
+if os.environ.get('HUSKY_LASER_3D_ENABLED')
+  j.add(package="husky_bringup", glob="launch/velodyne_config/*")
 
 j.install()

--- a/husky_description/package.xml
+++ b/husky_description/package.xml
@@ -24,6 +24,7 @@
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>lms1xx</run_depend>
+  <run_depend>velodyne_description</run_depend>
 
   <export>
   </export>

--- a/husky_description/urdf/accessories/sensor_arch.urdf.xacro
+++ b/husky_description/urdf/accessories/sensor_arch.urdf.xacro
@@ -3,6 +3,8 @@
 
     <xacro:macro name="sensor_arch" params="prefix parent size:=510 *origin">
 
+        <link name="${prefix}sensor_arch_base_link" />
+
         <!-- Spawn the sensor arch link -->
         <link name="${prefix}sensor_arch_mount_link">
              <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -19,11 +21,17 @@
              </collision>
         </link>
 
+        <joint name="${prefix}sensor_arch_base_link_joint" type="fixed">
+            <parent link="${parent}" />
+            <child link="${prefix}sensor_arch_base_link" />
+            <xacro:insert_block name="origin" />
+        </joint>
+
         <!-- Attach the sensor arch to the top plate -->
         <joint name="${prefix}sensor_arch_mount" type="fixed">
-             <xacro:insert_block name="origin"/>
-             <parent link="${parent}"/>
+             <parent link="${prefix}sensor_arch_base_link"/>
              <child link="${prefix}sensor_arch_mount_link"/>
+             <origin xyz="0 0 ${size/1000}" rpy="0 0 0" />
         </joint>
 
     </xacro:macro>

--- a/husky_description/urdf/accessories/vlp16_mount.urdf.xacro
+++ b/husky_description/urdf/accessories/vlp16_mount.urdf.xacro
@@ -5,8 +5,8 @@
     <!--
       The VLP16 is mounted to a pair of extrusion rods on top of the main sensor arch
     -->
-    <link name="${prefix}_vlp16_mount_base_link" />
-    <link name="${prefix}_vlp16_mount_left_support">
+    <link name="${prefix}vlp16_mount_base_link" />
+    <link name="${prefix}vlp16_mount_left_support">
       <visual>
         <geometry>
           <box size="0.012 0.012 ${height}" />
@@ -23,7 +23,7 @@
         <origin xyz="0 0 0" rpy="0 0 0" />
       </collision>
     </link>
-    <link name="${prefix}_vlp16_mount_right_support">
+    <link name="${prefix}vlp16_mount_right_support">
       <visual>
         <geometry>
           <box size="0.012 0.012 ${height}" />
@@ -41,23 +41,23 @@
       </collision>
     </link>
 
-    <joint name="${prefix}_vlp16_mount_base_link_joint" type="fixed">
+    <joint name="${prefix}vlp16_mount_base_link_joint" type="fixed">
       <parent link="${parent_link}" />
-      <child link="${prefix}_vlp16_mount_base_link" />
+      <child link="${prefix}vlp16_mount_base_link" />
       <xacro:insert_block name="origin" />
     </joint>
-    <joint name="${prefix}_vlp16_mount_left_support_joint" type="fixed">
-      <parent link="${prefix}_vlp16_mount_base_link" />
-      <child link="${prefix}_vlp16_mount_left_support" />
+    <joint name="${prefix}vlp16_mount_left_support_joint" type="fixed">
+      <parent link="${prefix}vlp16_mount_base_link" />
+      <child link="${prefix}vlp16_mount_left_support" />
       <origin xyz="0 0.04 ${height/2}" rpy="0 0 0"/>
     </joint>
-    <joint name="${prefix}_vlp16_mount_right_support_joint" type="fixed">
-      <parent link="${prefix}_vlp16_mount_base_link" />
-      <child link="${prefix}_vlp16_mount_right_support" />
+    <joint name="${prefix}vlp16_mount_right_support_joint" type="fixed">
+      <parent link="${prefix}vlp16_mount_base_link" />
+      <child link="${prefix}vlp16_mount_right_support" />
       <origin xyz="0 -0.04 ${height/2}" rpy="0 0 0"/>
     </joint>
 
-    <xacro:VLP-16 parent="${prefix}_vlp16_mount_base_link" topic="${topic}">
+    <xacro:VLP-16 parent="${prefix}vlp16_mount_base_link" topic="${topic}">
       <origin xyz="0 0 ${height}" rpy="0 0 0" />
     </xacro:VLP-16>
   </xacro:macro>

--- a/husky_description/urdf/accessories/vlp16_mount.urdf.xacro
+++ b/husky_description/urdf/accessories/vlp16_mount.urdf.xacro
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro" />
+  <xacro:macro name="vlp16_mount" params="prefix parent_link topic height:=0.12 *origin">
+    <!--
+      The VLP16 is mounted to a pair of extrusion rods on top of the main sensor arch
+    -->
+    <link name="${prefix}_vlp16_mount_base_link" />
+    <link name="${prefix}_vlp16_mount_left_support">
+      <visual>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </visual>
+      <collision>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </collision>
+    </link>
+    <link name="${prefix}_vlp16_mount_right_support">
+      <visual>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </visual>
+      <collision>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </collision>
+    </link>
+
+    <joint name="${prefix}_vlp16_mount_base_link_joint" type="fixed">
+      <parent link="${parent_link}" />
+      <child link="${prefix}_vlp16_mount_base_link" />
+      <xacro:insert_block name="origin" />
+    </joint>
+    <joint name="${prefix}_vlp16_mount_left_support_joint" type="fixed">
+      <parent link="${prefix}_vlp16_mount_base_link" />
+      <child link="${prefix}_vlp16_mount_left_support" />
+      <origin xyz="0 0.04 ${height/2}" rpy="0 0 0"/>
+    </joint>
+    <joint name="${prefix}_vlp16_mount_right_support_joint" type="fixed">
+      <parent link="${prefix}_vlp16_mount_base_link" />
+      <child link="${prefix}_vlp16_mount_right_support" />
+      <origin xyz="0 -0.04 ${height/2}" rpy="0 0 0"/>
+    </joint>
+
+    <xacro:VLP-16 parent="${prefix}_vlp16_mount_base_link" topic="${topic}">
+      <origin xyz="0 0 ${height}" rpy="0 0 0" />
+    </xacro:VLP-16>
+  </xacro:macro>
+</robot>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -47,6 +47,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <!-- Height of the sensor arch in mm.  Must be either 510 or 300 -->
   <xacro:arg name="sensor_arch_height"  default="$(optenv HUSKY_SENSOR_ARCH_HEIGHT 510)" />
+  <xacro:arg name="sensor_arch"         default="$(optenv HUSKY_SENSOR_ARCH 0)" />
 
   <xacro:arg name="robot_namespace" default="/" />
   <xacro:arg name="urdf_extras" default="empty.urdf" />
@@ -179,9 +180,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     Add the main sensor arch if the user has specifically enabled it, or if a sensor
     requires it for mounting
   -->
-  <xacro:property name="sensorbar_user_enabled"     value="$(optenv HUSKY_SENSOR_ARCH 0)" />
+  <xacro:property name="sensorbar_user_enabled"     value="$(arg sensor_arch)" />
   <xacro:property name="sensorbar_needed_realsense" value="$(arg realsense_enabled)" />
-  <xacro:property name="sensorbar_needed_lidar"     value="$(optenv HUSKY_LASER_3D 0)" />
+  <xacro:property name="sensorbar_needed_lidar"     value="$(arg laser_3d_enabled)" />
   <xacro:if value="${sensorbar_needed_realsense or sensorbar_user_enabled or sensorbar_needed_lidar}">
     <xacro:sensor_arch prefix="" parent="top_plate_link" size="$(arg sensor_arch_height)">
         <origin xyz="$(optenv HUSKY_SENSOR_ARCH_OFFSET 0 0 0)" rpy="$(optenv HUSKY_SENSOR_ARCH_RPY 0 0 0)"/>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -25,11 +25,19 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <robot name="husky" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:arg name="laser_enabled" default="false" />
+  <xacro:arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)" />
   <xacro:arg name="laser_xyz" default="$(optenv HUSKY_LMS1XX_XYZ 0.2206 0.0 0.00635)" />
   <xacro:arg name="laser_rpy" default="$(optenv HUSKY_LMS1XX_RPY 0.0 0.0 0.0)" />
 
-  <xacro:arg name="realsense_enabled" default="false" />
+  <xacro:arg name="laser_secondary_enabled" default="$(optenv HUSKY_LMS1XX_SECONDARY_ENABLED 0)" />
+  <xacro:arg name="laser_secondary_xyz" default="$(optenv HUSKY_LMS1XX_SECONDARY_XYZ -0.2206 0.0 0.00635)" />
+  <xacro:arg name="laser_secondary_rpy" default="$(optenv HUSKY_LMS1XX_SECONDARY_RPY 0.0 0.0 3.14159)" />
+
+  <xacro:arg name="laser_3d_enabled" default="$(optenv HUSKY_LASER_3D_ENABLED 0)" />
+  <xacro:arg name="laser_3d_xyz" default="$(optenv HUSKY_LASER_3D_XYZ 0 0 0)" />
+  <xacro:arg name="laser_3d_rpy" default="$(optenv HUSKY_LASER_3D_RPY 0 0 0)" />
+
+  <xacro:arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)" />
   <xacro:arg name="realsense_xyz" default="$(optenv HUSKY_REALSENSE_XYZ 0 0 0)" />
   <xacro:arg name="realsense_rpy" default="$(optenv HUSKY_REALSENSE_RPY 0 0 0)" />
   <xacro:arg name="realsense_mount" default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME sensor_arch_mount_link)" />
@@ -50,6 +58,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:include filename="$(find husky_description)/urdf/accessories/intel_realsense.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sensor_arch.urdf.xacro"/>
+  <xacro:include filename="$(find husky_description)/urdf/accessories/vlp16_mount.urdf.xacro"/>
 
   <xacro:property name="M_PI" value="3.14159"/>
 
@@ -140,43 +149,63 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <xacro:husky_decorate />
 
+  <!--
+    Add the primary and secondary lasers
+  -->
   <xacro:if value="$(arg laser_enabled)">
+    <xacro:sick_lms1xx_mount prefix="base"/>
 
-    <sick_lms1xx_mount prefix="base"/>
-
-    <sick_lms1xx frame="base_laser" topic="scan" robot_namespace="$(arg robot_namespace)"/>
+    <xacro:sick_lms1xx frame="base_laser" topic="scan" robot_namespace="$(arg robot_namespace)"/>
 
     <joint name="laser_mount_joint" type="fixed">
       <origin xyz="$(arg laser_xyz)" rpy="$(arg laser_rpy)" />
       <parent link="top_plate_link" />
       <child link="base_laser_mount" />
     </joint>
+  </xacro:if>
+  <xacro:if value="$(arg laser_secondary_enabled)">
+    <xacro:sick_lms1xx_mount prefix="rear"/>
 
+    <xacro:sick_lms1xx frame="rear_laser" topic="rear/scan" robot_namespace="$(arg robot_namespace)"/>
+
+    <joint name="laser_secondary_mount_joint" type="fixed">
+      <origin xyz="$(arg laser_secondary_xyz)" rpy="$(arg laser_secondary_rpy)" />
+      <parent link="top_plate_link" />
+      <child link="rear_laser_mount" />
+    </joint>
   </xacro:if>
 
   <!--
-    top sensor arch; include this if we have realsense enabled
-    keep this as a property to make it easier to add multiple conditions, should we need
-    the top bar for any additional sensors in the future
+    Add the main sensor arch if the user has specifically enabled it, or if a sensor
+    requires it for mounting
   -->
   <xacro:property name="sensorbar_user_enabled"     value="$(optenv HUSKY_SENSOR_ARCH 0)" />
   <xacro:property name="sensorbar_needed_realsense" value="$(arg realsense_enabled)" />
-  <xacro:if value="${sensorbar_needed_realsense or sensorbar_user_enabled}">
-    <xacro:property name="arch_height" value="$(arg sensor_arch_height)" />
+  <xacro:property name="sensorbar_needed_lidar"     value="$(optenv HUSKY_LASER_3D 0)" />
+  <xacro:if value="${sensorbar_needed_realsense or sensorbar_user_enabled or sensorbar_needed_lidar}">
     <xacro:sensor_arch prefix="" parent="top_plate_link" size="$(arg sensor_arch_height)">
-      <origin xyz="-0.35 0 ${arch_height / 1000.0}" rpy="0 0 -3.14"/>
-    </xacro:sensor_arch>
+        <origin xyz="$(optenv HUSKY_SENSOR_ARCH_OFFSET 0 0 0)" rpy="$(optenv HUSKY_SENSOR_ARCH_RPY 0 0 0)"/>
+      </xacro:sensor_arch>
   </xacro:if>
 
-  <!-- add the intel realsense to the topbar if needed -->
+  <!-- add the intel realsense to the sensor arch if needed -->
   <xacro:if value="$(arg realsense_enabled)">
     <link name="realsense_mountpoint"/>
     <joint name="realsense_mountpoint_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 -3.14159" />
+      <origin xyz="$(arg realsense_xyz)" rpy="$(arg realsense_rpy)" />
       <parent link="$(arg realsense_mount)"/>
       <child link="realsense_mountpoint" />
     </joint>
     <xacro:intel_realsense_mount prefix="camera" topic="realsense" parent_link="realsense_mountpoint"/>
+  </xacro:if>
+
+  <!--
+    Add the 3d laser to the sensor arch if needed
+  -->
+  <xacro:if value="$(arg laser_3d_enabled)">
+    <xacro:vlp16_mount prefix="" parent_link="sensor_arch_mount_link" topic="$(optenv HUSKY_LASER_3D_TOPIC points)">
+      <origin xyz="$(arg laser_3d_xyz)" rpy="$(arg laser_3d_rpy)" />
+    </xacro:vlp16_mount>
   </xacro:if>
 
   <gazebo>

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -27,7 +27,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="world_name" default="worlds/empty.world"/>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 1)"/>
   <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -27,7 +27,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="world_name" default="worlds/empty.world"/>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 0)"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)"/>
   <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -27,8 +27,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="world_name" default="worlds/empty.world"/>
 
-  <arg name="laser_enabled" default="true"/>
-  <arg name="realsense_enabled" default="false"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 0)"/>
+  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(arg world_name)"/> <!-- world_name is wrt GAZEBO_RESOURCE_PATH environment variable -->

--- a/husky_gazebo/launch/husky_playpen.launch
+++ b/husky_gazebo/launch/husky_playpen.launch
@@ -25,8 +25,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="true"/>
-  <arg name="realsense_enabled" default="false"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 0)"/>
+  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
 
   <include file="$(find husky_gazebo)/launch/playpen.launch" />
 

--- a/husky_gazebo/launch/husky_playpen.launch
+++ b/husky_gazebo/launch/husky_playpen.launch
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 0)"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 1)"/>
   <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
 
   <include file="$(find husky_gazebo)/launch/playpen.launch" />

--- a/husky_gazebo/launch/multi_husky_playpen.launch
+++ b/husky_gazebo/launch/multi_husky_playpen.launch
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="true"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 0)"/>
   <arg name="ur5_enabled" default="false"/>
 
  <include file="$(find multimaster_launch)/launch/multimaster_gazebo.launch"/>

--- a/husky_gazebo/launch/multi_husky_playpen.launch
+++ b/husky_gazebo/launch/multi_husky_playpen.launch
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 1)"/>
   <arg name="ur5_enabled" default="false"/>
 
  <include file="$(find multimaster_launch)/launch/multimaster_gazebo.launch"/>

--- a/husky_gazebo/launch/multi_husky_playpen.launch
+++ b/husky_gazebo/launch/multi_husky_playpen.launch
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 0)"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)"/>
   <arg name="ur5_enabled" default="false"/>
 
  <include file="$(find multimaster_launch)/launch/multimaster_gazebo.launch"/>

--- a/husky_gazebo/package.xml
+++ b/husky_gazebo/package.xml
@@ -29,6 +29,7 @@
   <run_depend>multimaster_launch</run_depend>
   <run_depend>pointcloud_to_laserscan</run_depend>
   <run_depend>rostopic</run_depend>
+  <run_depend>velodyne_gazebo_plugins</run_depend>
 
   <export>
   </export>

--- a/husky_viz/launch/view_model.launch
+++ b/husky_viz/launch/view_model.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
-  <arg name="realsense_enabled" default="false"/>
+  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)"/>
+  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
 
   <!-- Standalone launcher to visualize the robot model. -->
   <include file="$(find husky_description)/launch/description.launch">


### PR DESCRIPTION
A stripped-down, less-breaking version of the vlp16 branch, but that doesn't completely clobber the existing envars.
Improved the sensor arch support to allow xyz & rpy offsets, to allow the bar to be mounted in the center/front/rear as desired.  Used envars as the default for the laser_enabled and realsense_enabled args wherever they were referenced.