### PR TITLE
Update intel_realsense.urdf.xacro

### DIFF
--- a/husky_description/urdf/accessories/intel_realsense.urdf.xacro
+++ b/husky_description/urdf/accessories/intel_realsense.urdf.xacro
@@ -38,7 +38,7 @@
               <width>${width}</width>
               <height>${height}</height>
               <!-- TODO: check what format the Realsense hardware delivers and set this to match! -->
-              <format>RGB8</format>
+              <format>RGB_INT8</format>
             </image>
             <clip>
               <!-- give the color sensor a maximum range of 50m so that the simulation renders nicely -->


### PR DESCRIPTION
modify image format in sim to avoid log warn spam

Verified before an after that the image shows up on RVIZ, and the logwarn spam is not present post the change.