### PR TITLE
Make better use of envars for urdf customization

### DIFF
--- a/husky_control/launch/control.launch
+++ b/husky_control/launch/control.launch
@@ -9,10 +9,6 @@
   <arg name="config_extras"
        default="$(eval optenv('HUSKY_CONFIG_EXTRAS', find('husky_control') + '/config/empty.yaml'))"/>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
-  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED false)"/>
-  <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
-
   <include file="$(find multimaster_launch)/launch/multimaster_robot.launch" if="$(arg multimaster)">
     <arg name="gazebo_interface" value="$(find husky_control)/config/gazebo_interface.yaml" />
     <arg name="public_interface" value="$(find husky_control)/config/public_interface.yaml" />
@@ -22,9 +18,6 @@
 
   <!-- Load robot description -->
   <include file="$(find husky_description)/launch/description.launch" >
-    <arg name="laser_enabled" default="$(arg laser_enabled)"/>
-    <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
-    <arg name="urdf_extras" default="$(arg urdf_extras)"/>
   </include>
 
   <!-- Load controller configuration -->

--- a/husky_description/launch/description.launch
+++ b/husky_description/launch/description.launch
@@ -26,15 +26,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 <launch>
 
   <arg name="robot_namespace" default="/"/>
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
-  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED false)"/>
-  <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
 
   <param name="robot_description" command="$(find xacro)/xacro '$(find husky_description)/urdf/husky.urdf.xacro'
-    robot_namespace:=$(arg robot_namespace)
-    laser_enabled:=$(arg laser_enabled)
-    realsense_enabled:=$(arg realsense_enabled)
-    urdf_extras:=$(arg urdf_extras)
-    " />
+    robot_namespace:=$(arg robot_namespace)" />
 
 </launch>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -49,8 +49,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="sensor_arch_height"  default="$(optenv HUSKY_SENSOR_ARCH_HEIGHT 510)" />
   <xacro:arg name="sensor_arch"         default="$(optenv HUSKY_SENSOR_ARCH 0)" />
 
-  <xacro:arg name="robot_namespace" default="/" />
-  <xacro:arg name="urdf_extras" default="empty.urdf" />
+  <xacro:arg name="robot_namespace" default="$(optenv ROBOT_NAMESPACE /)" />
+  <xacro:arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS empty.urdf)" />
 
   <!-- Included URDF/XACRO Files -->
   <xacro:include filename="$(find husky_description)/urdf/decorations.urdf.xacro" />

--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -27,9 +27,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <arg name="world_name" default="worlds/empty.world"/>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 1)"/>
-  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
-
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(arg world_name)"/> <!-- world_name is wrt GAZEBO_RESOURCE_PATH environment variable -->
     <arg name="paused" value="false"/>
@@ -40,8 +37,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </include>
 
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
-    <arg name="laser_enabled" value="$(arg laser_enabled)"/>
-    <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>
 
 </launch>

--- a/husky_gazebo/launch/husky_playpen.launch
+++ b/husky_gazebo/launch/husky_playpen.launch
@@ -25,14 +25,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LASER_LMS1XX_ENABLED 1)"/>
-  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
-
   <include file="$(find husky_gazebo)/launch/playpen.launch" />
 
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
-    <arg name="laser_enabled" value="$(arg laser_enabled)"/>
-    <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>
 
 </launch>

--- a/husky_gazebo/launch/multi_husky_playpen.launch
+++ b/husky_gazebo/launch/multi_husky_playpen.launch
@@ -25,22 +25,17 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 1)"/>
-  <arg name="ur5_enabled" default="false"/>
-
  <include file="$(find multimaster_launch)/launch/multimaster_gazebo.launch"/>
 
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find husky_gazebo)/launch/playpen.launch" />
 
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
-    <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="robot_namespace" value="husky_alpha"/>
     <arg name="multimaster" value="true"/>
   </include>
 
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
-    <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="robot_namespace" value="husky_beta"/>
     <arg name="multimaster" value="true"/>
     <arg name="x" value="1.0"/>
@@ -49,7 +44,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </include>
 
   <include file="$(find husky_gazebo)/launch/spawn_husky.launch">
-    <arg name="laser_enabled" value="$(arg laser_enabled)"/>
     <arg name="robot_namespace" value="husky_gamma"/>
     <arg name="multimaster" value="true"/>
     <arg name="x" value="-3.0"/>

--- a/husky_gazebo/launch/spawn_husky.launch
+++ b/husky_gazebo/launch/spawn_husky.launch
@@ -34,10 +34,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <arg name="z" default="0.0"/>
   <arg name="yaw" default="0.0"/>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
-  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED false)"/>
-  <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
-
   <!-- Optionally disable teleop control -->
   <arg name="joystick" default="true" />
 
@@ -46,9 +42,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <group if="$(arg multimaster)">
       <include file="$(find husky_description)/launch/description.launch" >
         <arg name="robot_namespace" value="$(arg robot_namespace)"/>
-        <arg name="laser_enabled" default="$(arg laser_enabled)"/>
-        <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
-        <arg name="urdf_extras" default="$(arg urdf_extras)"/>
       </include>
 
       <include file="$(find multimaster_launch)/launch/multimaster_gazebo_robot.launch">
@@ -65,9 +58,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <group unless="$(arg multimaster)">
       <include file="$(find husky_control)/launch/control.launch">
         <arg name="multimaster" value="$(arg multimaster)"/>
-        <arg name="laser_enabled" value="$(arg laser_enabled)"/>
-        <arg name="realsense_enabled" default="$(arg realsense_enabled)"/>
-        <arg name="urdf_extras" value="$(arg urdf_extras)"/>
       </include>
       <include file="$(find husky_control)/launch/teleop.launch">
         <arg name="joystick" value="$(arg joystick)" />
@@ -75,7 +65,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     </group>
 
     <!-- Additional nodes for specific accessories -->
-    <group if="$(arg realsense_enabled)">
+    <group if="$(optenv HUSKY_REALSENSE_ENABLED 0)">
       <include file="$(find husky_gazebo)/launch/realsense.launch" />
     </group>
 

--- a/husky_viz/launch/view_model.launch
+++ b/husky_viz/launch/view_model.launch
@@ -1,13 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
-  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)"/>
-  <arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)"/>
-
   <!-- Standalone launcher to visualize the robot model. -->
   <include file="$(find husky_description)/launch/description.launch">
-    <arg name="laser_enabled" value="$(arg laser_enabled)"/>
-    <arg name="realsense_enabled" value="$(arg realsense_enabled)"/>
   </include>
 
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />


### PR DESCRIPTION
Remove the laser_enabled, realsense_enabled, and urdf_extras args from the simulation and visualization packages, refactor the description launch file & base URDF to make better use of envars.  This should make it easier to simulate customized robots by just running `source /etc/ros/setup.bash` and launching the sim.  This should also eliminate the need to explicitly specify the urdf_extras xacro argument when using the moveit setup assistant.