### PR TITLE
Eliminate roslint errors

### DIFF
--- a/husky_base/include/husky_base/husky_diagnostics.h
+++ b/husky_base/include/husky_base/husky_diagnostics.h
@@ -40,69 +40,69 @@
 namespace husky_base
 {
 
-  class HuskySoftwareDiagnosticTask :
-    public diagnostic_updater::DiagnosticTask
+class HuskySoftwareDiagnosticTask :
+  public diagnostic_updater::DiagnosticTask
+{
+public:
+  explicit HuskySoftwareDiagnosticTask(husky_msgs::HuskyStatus &msg, double target_control_freq);
+
+  void run(diagnostic_updater::DiagnosticStatusWrapper &stat);
+
+  void updateControlFrequency(double frequency);
+
+private:
+  void reset();
+
+  double control_freq_, target_control_freq_;
+  husky_msgs::HuskyStatus &msg_;
+};
+
+template<typename T>
+class HuskyHardwareDiagnosticTask :
+  public diagnostic_updater::DiagnosticTask
+{
+public:
+  explicit HuskyHardwareDiagnosticTask(husky_msgs::HuskyStatus &msg);
+
+  void run(diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
-  public:
-    explicit HuskySoftwareDiagnosticTask(husky_msgs::HuskyStatus &msg, double target_control_freq);
-
-    void run(diagnostic_updater::DiagnosticStatusWrapper &stat);
-
-    void updateControlFrequency(double frequency);
-
-  private:
-    void reset();
-
-    double control_freq_, target_control_freq_;
-    husky_msgs::HuskyStatus &msg_;
-  };
-
-  template<typename T>
-  class HuskyHardwareDiagnosticTask :
-    public diagnostic_updater::DiagnosticTask
-  {
-  public:
-    explicit HuskyHardwareDiagnosticTask(husky_msgs::HuskyStatus &msg);
-
-    void run(diagnostic_updater::DiagnosticStatusWrapper &stat)
+    typename horizon_legacy::Channel<T>::Ptr latest = horizon_legacy::Channel<T>::requestData(1.0);
+    if (latest)
     {
-      typename horizon_legacy::Channel<T>::Ptr latest = horizon_legacy::Channel<T>::requestData(1.0);
-      if (latest)
-      {
-        update(stat, latest);
-      }
+      update(stat, latest);
     }
+  }
 
-    void update(diagnostic_updater::DiagnosticStatusWrapper &stat, typename horizon_legacy::Channel<T>::Ptr &status);
+  void update(diagnostic_updater::DiagnosticStatusWrapper &stat, typename horizon_legacy::Channel<T>::Ptr &status);
 
-  private:
-    husky_msgs::HuskyStatus &msg_;
-  };
+private:
+  husky_msgs::HuskyStatus &msg_;
+};
 
-  template<>
-  HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus>::HuskyHardwareDiagnosticTask(husky_msgs::HuskyStatus &msg);
+template<>
+HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus>::HuskyHardwareDiagnosticTask(husky_msgs::HuskyStatus &msg);
 
-  template<>
-  HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem>::HuskyHardwareDiagnosticTask(husky_msgs::HuskyStatus &msg);
+template<>
+HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem>::HuskyHardwareDiagnosticTask(husky_msgs::HuskyStatus &msg);
 
-  template<>
-  HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus>::HuskyHardwareDiagnosticTask(
-    husky_msgs::HuskyStatus &msg);
+template<>
+HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus>::HuskyHardwareDiagnosticTask(
+  husky_msgs::HuskyStatus &msg);
 
-  template<>
-  void HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus>::update(
-    diagnostic_updater::DiagnosticStatusWrapper &stat,
-    horizon_legacy::Channel<clearpath::DataSystemStatus>::Ptr &status);
+template<>
+void HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus>::update(
+  diagnostic_updater::DiagnosticStatusWrapper &stat,
+  horizon_legacy::Channel<clearpath::DataSystemStatus>::Ptr &status);
 
-  template<>
-  void HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem>::update(
-    diagnostic_updater::DiagnosticStatusWrapper &stat,
-    horizon_legacy::Channel<clearpath::DataPowerSystem>::Ptr &status);
+template<>
+void HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem>::update(
+  diagnostic_updater::DiagnosticStatusWrapper &stat,
+  horizon_legacy::Channel<clearpath::DataPowerSystem>::Ptr &status);
 
-  template<>
-  void HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus>::update(
-    diagnostic_updater::DiagnosticStatusWrapper &stat,
-    horizon_legacy::Channel<clearpath::DataSafetySystemStatus>::Ptr &status);
+template<>
+void HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus>::update(
+  diagnostic_updater::DiagnosticStatusWrapper &stat,
+  horizon_legacy::Channel<clearpath::DataSafetySystemStatus>::Ptr &status);
 
 }  // namespace husky_base
 #endif  // HUSKY_BASE_HUSKY_DIAGNOSTICS_H

--- a/husky_base/include/husky_base/husky_hardware.h
+++ b/husky_base/include/husky_base/husky_hardware.h
@@ -45,73 +45,73 @@
 namespace husky_base
 {
 
+/**
+* Class representing Husky hardware, allows for ros_control to modify internal state via joint interfaces
+*/
+class HuskyHardware :
+  public hardware_interface::RobotHW
+{
+public:
+  HuskyHardware(ros::NodeHandle nh, ros::NodeHandle private_nh, double target_control_freq);
+
+  void updateJointsFromHardware();
+
+  void writeCommandsToHardware();
+
+  void updateDiagnostics();
+
+  void reportLoopDuration(const ros::Duration &duration);
+
+private:
+  void initializeDiagnostics();
+
+  void resetTravelOffset();
+
+  void registerControlInterfaces();
+
+  double linearToAngular(const double &travel) const;
+
+  double angularToLinear(const double &angle) const;
+
+  void limitDifferentialSpeed(double &travel_speed_left, double &travel_speed_right);
+
+  ros::NodeHandle nh_, private_nh_;
+
+  // ROS Control interfaces
+  hardware_interface::JointStateInterface joint_state_interface_;
+  hardware_interface::VelocityJointInterface velocity_joint_interface_;
+
+  // Diagnostics
+  ros::Publisher diagnostic_publisher_;
+  husky_msgs::HuskyStatus husky_status_msg_;
+  diagnostic_updater::Updater diagnostic_updater_;
+  HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus> system_status_task_;
+  HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem> power_status_task_;
+  HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus> safety_status_task_;
+  HuskySoftwareDiagnosticTask software_status_task_;
+
+  // ROS Parameters
+  double wheel_diameter_, max_accel_, max_speed_;
+
+  double polling_timeout_;
+
   /**
-  * Class representing Husky hardware, allows for ros_control to modify internal state via joint interfaces
+  * Joint structure that is hooked to ros_control's InterfaceManager, to allow control via diff_drive_controller
   */
-  class HuskyHardware :
-    public hardware_interface::RobotHW
+  struct Joint
   {
-  public:
-    HuskyHardware(ros::NodeHandle nh, ros::NodeHandle private_nh, double target_control_freq);
+    double position;
+    double position_offset;
+    double velocity;
+    double effort;
+    double velocity_command;
 
-    void updateJointsFromHardware();
-
-    void writeCommandsToHardware();
-
-    void updateDiagnostics();
-
-    void reportLoopDuration(const ros::Duration &duration);
-
-  private:
-
-    void initializeDiagnostics();
-
-    void resetTravelOffset();
-
-    void registerControlInterfaces();
-
-    double linearToAngular(const double &travel) const;
-
-    double angularToLinear(const double &angle) const;
-
-    void limitDifferentialSpeed(double &travel_speed_left, double &travel_speed_right);
-
-    ros::NodeHandle nh_, private_nh_;
-
-    // ROS Control interfaces
-    hardware_interface::JointStateInterface joint_state_interface_;
-    hardware_interface::VelocityJointInterface velocity_joint_interface_;
-
-    // Diagnostics
-    ros::Publisher diagnostic_publisher_;
-    husky_msgs::HuskyStatus husky_status_msg_;
-    diagnostic_updater::Updater diagnostic_updater_;
-    HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus> system_status_task_;
-    HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem> power_status_task_;
-    HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus> safety_status_task_;
-    HuskySoftwareDiagnosticTask software_status_task_;
-
-    // ROS Parameters
-    double wheel_diameter_, max_accel_, max_speed_;
-
-    double polling_timeout_;
-
-    /**
-    * Joint structure that is hooked to ros_control's InterfaceManager, to allow control via diff_drive_controller
-    */
-    struct Joint
-    {
-      double position;
-      double position_offset;
-      double velocity;
-      double effort;
-      double velocity_command;
-
-      Joint() :
-        position(0), velocity(0), effort(0), velocity_command(0)
-      { }
-    } joints_[4];
-  };
+    Joint() :
+      position(0), velocity(0), effort(0), velocity_command(0)
+    { }
+  }
+  joints_[4];
+};
 
 }  // namespace husky_base
 #endif  // HUSKY_BASE_HUSKY_HARDWARE_H

--- a/husky_base/src/husky_base.cpp
+++ b/husky_base/src/husky_base.cpp
@@ -44,7 +44,6 @@ void controlLoop(husky_base::HuskyHardware &husky,
                  controller_manager::ControllerManager &cm,
                  time_source::time_point &last_time)
 {
-
   // Calculate monotonic time difference
   time_source::time_point this_time = time_source::now();
   boost::chrono::duration<double> elapsed_duration = this_time - last_time;

--- a/husky_base/src/husky_diagnostics.cpp
+++ b/husky_base/src/husky_diagnostics.cpp
@@ -30,6 +30,8 @@
 */
 
 #include "husky_base/husky_diagnostics.h"
+#include <algorithm>
+#include <limits>
 
 namespace
 {

--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -30,7 +30,9 @@
 */
 
 #include "husky_base/husky_hardware.h"
+#include <algorithm>
 #include <boost/assign/list_of.hpp>
+#include <string>
 
 namespace
 {
@@ -72,8 +74,8 @@ namespace husky_base
   */
   void HuskyHardware::resetTravelOffset()
   {
-    horizon_legacy::Channel<clearpath::DataEncoders>::Ptr enc = horizon_legacy::Channel<clearpath::DataEncoders>::requestData(
-      polling_timeout_);
+    horizon_legacy::Channel<clearpath::DataEncoders>::Ptr enc;
+    enc = horizon_legacy::Channel<clearpath::DataEncoders>::requestData(polling_timeout_);
     if (enc)
     {
       for (int i = 0; i < 4; i++)
@@ -143,12 +145,13 @@ namespace husky_base
   */
   void HuskyHardware::updateJointsFromHardware()
   {
-
-    horizon_legacy::Channel<clearpath::DataEncoders>::Ptr enc = horizon_legacy::Channel<clearpath::DataEncoders>::requestData(
+    horizon_legacy::Channel<clearpath::DataEncoders>::Ptr enc;
+    enc = horizon_legacy::Channel<clearpath::DataEncoders>::requestData(
       polling_timeout_);
     if (enc)
     {
-      ROS_DEBUG_STREAM("Received travel information (L:" << enc->getTravel(LEFT) << " R:" << enc->getTravel(RIGHT) << ")");
+      ROS_DEBUG_STREAM("Received travel information (L:" << enc->getTravel(LEFT)
+          << " R:" << enc->getTravel(RIGHT) << ")");
       for (int i = 0; i < 4; i++)
       {
         double delta = linearToAngular(enc->getTravel(i % 2)) - joints_[i].position - joints_[i].position_offset;
@@ -167,11 +170,12 @@ namespace husky_base
       }
     }
 
-    horizon_legacy::Channel<clearpath::DataDifferentialSpeed>::Ptr speed = horizon_legacy::Channel<clearpath::DataDifferentialSpeed>::requestData(
-      polling_timeout_);
+    horizon_legacy::Channel<clearpath::DataDifferentialSpeed>::Ptr speed;
+    speed = horizon_legacy::Channel<clearpath::DataDifferentialSpeed>::requestData(polling_timeout_);
     if (speed)
     {
-      ROS_DEBUG_STREAM("Received linear speed information (L:" << speed->getLeftSpeed() << " R:" << speed->getRightSpeed() << ")");
+      ROS_DEBUG_STREAM("Received linear speed information (L:" << speed->getLeftSpeed()
+          << " R:" << speed->getRightSpeed() << ")");
       for (int i = 0; i < 4; i++)
       {
         if (i % 2 == LEFT)


### PR DESCRIPTION
Get rid of all these when running

```
catkin build husky_base --no-deps --catkin-make-args roslint
```
```
src/husky_base.cpp:47:  Redundant blank line at the start of a code block should be deleted.  [whitespace/blank_line] [2]
src/husky_hardware.cpp:75:  Lines should be <= 120 characters long  [whitespace/line_length] [2]
src/husky_hardware.cpp:146:  Redundant blank line at the start of a code block should be deleted.  [whitespace/blank_line] [2]
src/husky_hardware.cpp:147:  Lines should be <= 120 characters long  [whitespace/line_length] [2]
src/husky_hardware.cpp:151:  Lines should be <= 120 characters long  [whitespace/line_length] [2]
src/husky_hardware.cpp:170:  Lines should be <= 120 characters long  [whitespace/line_length] [2]
src/husky_hardware.cpp:174:  Lines should be <= 120 characters long  [whitespace/line_length] [2]
src/husky_hardware.cpp:61:  Add #include <string> for string  [build/include_what_you_use] [4]
src/husky_hardware.cpp:215:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
src/husky_diagnostics.cpp:230:  Add #include <algorithm> for min  [build/include_what_you_use] [4]
src/husky_diagnostics.cpp:253:  Add #include <limits> for numeric_limits<>  [build/include_what_you_use] [4]
include/husky_base/husky_diagnostics.h:43:  Do not indent within a namespace  [runtime/indentation_namespace] [4]
include/husky_base/husky_diagnostics.h:61:  Do not indent within a namespace  [runtime/indentation_namespace] [4]
include/husky_base/husky_hardware.h:51:  Do not indent within a namespace  [runtime/indentation_namespace] [4]
include/husky_base/husky_hardware.h:66:  Do not leave a blank line after "private:"  [whitespace/blank_line] [3]
include/husky_base/husky_hardware.h:113:  } should be on a line by itself  [whitespace/braces] [4]
make[3]: *** [CMakeFiles/roslint_husky_base.dir/build.make:57: roslint_husky_base] Error 1
make[2]: *** [CMakeFiles/Makefile2:299: CMakeFiles/roslint_husky_base.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1657: CMakeFiles/roslint.dir/rule] Error 2
make: *** [Makefile:877: roslint] Error 2
```

Some of the line lengths could have been fixed with `auto` instead.

Anything could be fixed by ignoring it with for example:

```
set(ROSLINT_CPP_OPTS "--filter=-runtime/indentation_namespace")
```