### PR TITLE
WIP - Accessories refactor

### DIFF
--- a/husky_bringup/launch/accessories.launch
+++ b/husky_bringup/launch/accessories.launch
@@ -23,4 +23,7 @@
   <group if="$(eval len(optenv('HUSKY_LMS1XX_IP', '')) > 0)">
     <include file="$(find husky_bringup)/launch/lms1xx_config/lms1xx.launch" />
   </group>
+  <group if="$(optenv HUSKY_LASER_3D_ENABLED 0)">
+    <include file="$(find husky_bringup)/launch/velodyne_config/vlp16.launch" />
+  </group>
 </launch>

--- a/husky_bringup/launch/accessories.launch
+++ b/husky_bringup/launch/accessories.launch
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- IMU, triggered by presence of the appropriate device -->
+  <group if="$(eval os.path.exists('/dev/clearpath/imu') or os.path.exists('/dev/clearpath/um6'))">
+    <include file="$(find husky_bringup)/launch/um6_config/um6.launch" />
+  </group>
+  <group if="$(eval os.path.exists('/dev/clearpath/um7'))">
+    <include file="$(find husky_bringup)/launch/um7_config/um7.launch" />
+  </group>
+  <group if="$(eval os.path.exists('/dev/microstrain_gx3'))">
+    <include file="$(find husky_bringup)/launch/microstrain_gx3_config/microstrain_gx3.launch" />
+  </group>
+  <group if="$(eval os.path.exists('/dev/microstrain_gx5'))">
+    <include file="$(find husky_bringup)/launch/microstrain_gx5_config/microstrain_gx5.launch" />
+  </group>
+
+  <!-- GPS, triggered by the presence of the appropriate device -->
+  <group if="$(eval os.path.exists('/dev/clearpath/gps'))">
+    <include file="$(find husky_bringup)/launch/navsat_config/navsat.launch" />
+  </group>
+
+  <!-- Lidar, triggered by envars -->
+  <group if="$(eval len(optenv('HUSKY_LMS1XX_IP', '')) > 0)">
+    <include file="$(find husky_bringup)/launch/lms1xx_config/lms1xx.launch" />
+  </group>
+</launch>

--- a/husky_bringup/launch/lms1xx_config/lms1xx.launch
+++ b/husky_bringup/launch/lms1xx_config/lms1xx.launch
@@ -1,10 +1,17 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="lms1xx_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)" />
+  <arg name="lms1xx_secondary_enabled" default="$(optenv HUSKY_LMS1XX_SECONDARY_ENABLED false)" />
   <group if="$(arg lms1xx_enabled)">
     <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
       <param name="host" value="$(env HUSKY_LMS1XX_IP)" />
       <param name="frame_id" value="base_laser" />
+    </node>
+  </group>
+  <group if="$(arg lms1xx_secondary_enabled)">
+    <node pkg="lms1xx" name="lms1xx_secondary" type="LMS1xx_node">
+      <param name="host" value="$(env HUSKY_LMS1XX_SECONDARY_IP)" />
+      <param name="frame_id" value="rear_laser" />
     </node>
   </group>
 </launch>

--- a/husky_bringup/launch/velodyne_config/vlp16.launch
+++ b/husky_bringup/launch/velodyne_config/vlp16.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="laser_3d_enabled" default="$(optenv HUSKY_LASER_3D_ENABLED false)" />
+  <group if="$(arg laser_3d_enabled)">
+    <include file="$(find velodyne_pointcloud)/launch/VLP16_points.launch">
+      <arg name="device_ip" value="$(optenv HUSKY_LASER_3D_HOST 192.168.131.20)" />
+      <remap from="velodyne_points" to="$(optenv HUSKY_LASER_3D_TOPIC points)" />
+    </include>
+  </group>
+</launch>

--- a/husky_bringup/scripts/install
+++ b/husky_bringup/scripts/install
@@ -7,23 +7,6 @@ j = robot_upstart.Job(name="ros", interface=os.environ.get('ROBOT_NETWORK'), wor
 
 # Stuff to launch on system startup.
 j.add(package="husky_base", glob="launch/*")
-
-if os.path.exists('/dev/clearpath/imu') or os.path.exists('/dev/clearpath/um6'):
-  j.add(package="husky_bringup", glob="launch/um6_config/*")
-
-if os.path.exists('/dev/clearpath/um7'):
-  j.add(package="husky_bringup", glob="launch/um7_config/*")
-
-if os.path.exists('/dev/microstrain_gx3'):
-  j.add(package="husky_bringup", glob="launch/microstrain_gx3_config/*")
-
-if os.path.exists('/dev/microstrain_gx5'):
-  j.add(package="husky_bringup", glob="launch/microstrain_gx5_config/*")
-
-if os.path.exists('/dev/clearpath/gps'):
-  j.add(package="husky_bringup", glob="launch/navsat_config/*")
-
-if os.environ.get('HUSKY_LMS1XX_IP'):
-  j.add(package="husky_bringup", glob="launch/lms1xx_config/*")
+j.add(package="husky_bringup", glob="launch/*")
 
 j.install()

--- a/husky_description/urdf/accessories/velodyne_vlp16_mount.urdf.xacro
+++ b/husky_description/urdf/accessories/velodyne_vlp16_mount.urdf.xacro
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro" />
+  <xacro:macro name="vlp16_mount" params="prefix parent_link topic height:=0.12 *origin">
+    <!--
+      The VLP16 is mounted to a pair of extrusion rods on top of the main sensor arch
+    -->
+    <link name="${prefix}vlp16_mount_base_link" />
+    <link name="${prefix}vlp16_mount_left_support">
+      <visual>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </visual>
+      <collision>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </collision>
+    </link>
+    <link name="${prefix}vlp16_mount_right_support">
+      <visual>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </visual>
+      <collision>
+        <geometry>
+          <box size="0.012 0.012 ${height}" />
+        </geometry>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+      </collision>
+    </link>
+
+    <joint name="${prefix}vlp16_mount_base_link_joint" type="fixed">
+      <parent link="${parent_link}" />
+      <child link="${prefix}vlp16_mount_base_link" />
+      <xacro:insert_block name="origin" />
+    </joint>
+    <joint name="${prefix}vlp16_mount_left_support_joint" type="fixed">
+      <parent link="${prefix}vlp16_mount_base_link" />
+      <child link="${prefix}vlp16_mount_left_support" />
+      <origin xyz="0 0.04 ${height/2}" rpy="0 0 0"/>
+    </joint>
+    <joint name="${prefix}vlp16_mount_right_support_joint" type="fixed">
+      <parent link="${prefix}vlp16_mount_base_link" />
+      <child link="${prefix}vlp16_mount_right_support" />
+      <origin xyz="0 -0.04 ${height/2}" rpy="0 0 0"/>
+    </joint>
+
+    <xacro:VLP-16 parent="${prefix}vlp16_mount_base_link" topic="${topic}">
+      <origin xyz="0 0 ${height}" rpy="0 0 0" />
+    </xacro:VLP-16>
+  </xacro:macro>
+</robot>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -49,8 +49,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="sensor_arch_height"  default="$(optenv HUSKY_SENSOR_ARCH_HEIGHT 510)" />
   <xacro:arg name="sensor_arch"         default="$(optenv HUSKY_SENSOR_ARCH 0)" />
 
-  <xacro:arg name="robot_namespace" default="/" />
-  <xacro:arg name="urdf_extras" default="empty.urdf" />
+  <xacro:arg name="robot_namespace" default="$(optenv ROBOT_NAMESPACE /)" />
+  <xacro:arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS empty.urdf)" />
+  <xacro:arg name="cpr_urdf_extras" default="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
 
   <!-- Included URDF/XACRO Files -->
   <xacro:include filename="$(find husky_description)/urdf/decorations.urdf.xacro" />
@@ -59,7 +60,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:include filename="$(find husky_description)/urdf/accessories/intel_realsense.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sensor_arch.urdf.xacro"/>
-  <xacro:include filename="$(find husky_description)/urdf/accessories/velodyne_vlp16_mount.urdf.xacro"/>
+  <xacro:include filename="$(find husky_description)/urdf/accessories/vlp16_mount.urdf.xacro"/>
 
   <xacro:property name="M_PI" value="3.14159"/>
 
@@ -249,5 +250,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <!-- Optional custom includes. -->
   <xacro:include filename="$(arg urdf_extras)" />
+
+  <!-- Optional for Clearpath internal softwares -->
+  <xacro:include filename="$(arg cpr_urdf_extras)" />
 
 </robot>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -25,17 +25,29 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <robot name="husky" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:arg name="laser_enabled" default="false" />
+  <xacro:arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED 0)" />
   <xacro:arg name="laser_xyz" default="$(optenv HUSKY_LMS1XX_XYZ 0.2206 0.0 0.00635)" />
   <xacro:arg name="laser_rpy" default="$(optenv HUSKY_LMS1XX_RPY 0.0 0.0 0.0)" />
 
-  <xacro:arg name="realsense_enabled" default="false" />
+  <xacro:arg name="laser_secondary_enabled" default="$(optenv HUSKY_LMS1XX_SECONDARY_ENABLED 0)" />
+  <xacro:arg name="laser_secondary_xyz" default="$(optenv HUSKY_LMS1XX_SECONDARY_XYZ -0.2206 0.0 0.00635)" />
+  <xacro:arg name="laser_secondary_rpy" default="$(optenv HUSKY_LMS1XX_SECONDARY_RPY 0.0 0.0 3.14159)" />
+
+  <xacro:arg name="laser_3d_enabled" default="$(optenv HUSKY_LASER_3D_ENABLED 0)" />
+  <xacro:arg name="laser_3d_xyz" default="$(optenv HUSKY_LASER_3D_XYZ 0 0 0)" />
+  <xacro:arg name="laser_3d_rpy" default="$(optenv HUSKY_LASER_3D_RPY 0 0 0)" />
+
+  <xacro:arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)" />
   <xacro:arg name="realsense_xyz" default="$(optenv HUSKY_REALSENSE_XYZ 0 0 0)" />
   <xacro:arg name="realsense_rpy" default="$(optenv HUSKY_REALSENSE_RPY 0 0 0)" />
   <xacro:arg name="realsense_mount" default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME sensor_arch_mount_link)" />
 
   <xacro:property name="husky_front_bumper_extend" value="$(optenv HUSKY_FRONT_BUMPER_EXTEND 0)" />
   <xacro:property name="husky_rear_bumper_extend" value="$(optenv HUSKY_REAR_BUMPER_EXTEND 0)" />
+
+  <!-- Height of the sensor arch in mm.  Must be either 510 or 300 -->
+  <xacro:arg name="sensor_arch_height"  default="$(optenv HUSKY_SENSOR_ARCH_HEIGHT 510)" />
+  <xacro:arg name="sensor_arch"         default="$(optenv HUSKY_SENSOR_ARCH 0)" />
 
   <xacro:arg name="robot_namespace" default="/" />
   <xacro:arg name="urdf_extras" default="empty.urdf" />
@@ -47,6 +59,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:include filename="$(find husky_description)/urdf/accessories/intel_realsense.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sensor_arch.urdf.xacro"/>
+  <xacro:include filename="$(find husky_description)/urdf/accessories/velodyne_vlp16_mount.urdf.xacro"/>
 
   <xacro:property name="M_PI" value="3.14159"/>
 
@@ -137,8 +150,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
   <xacro:husky_decorate />
 
+  <!--
+    Add the primary and secondary lasers
+  -->
   <xacro:if value="$(arg laser_enabled)">
-
     <xacro:sick_lms1xx_mount prefix="base"/>
 
     <xacro:sick_lms1xx frame="base_laser" topic="scan" robot_namespace="$(arg robot_namespace)"/>
@@ -148,30 +163,50 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       <parent link="top_plate_link" />
       <child link="base_laser_mount" />
     </joint>
+  </xacro:if>
+  <xacro:if value="$(arg laser_secondary_enabled)">
+    <xacro:sick_lms1xx_mount prefix="rear"/>
 
+    <xacro:sick_lms1xx frame="rear_laser" topic="rear/scan" robot_namespace="$(arg robot_namespace)"/>
+
+    <joint name="laser_secondary_mount_joint" type="fixed">
+      <origin xyz="$(arg laser_secondary_xyz)" rpy="$(arg laser_secondary_rpy)" />
+      <parent link="top_plate_link" />
+      <child link="rear_laser_mount" />
+    </joint>
   </xacro:if>
 
   <!--
-    top sensor arch; include this if we have realsense enabled
-    keep this as a property to make it easier to add multiple conditions, should we need
-    the top bar for any additional sensors in the future
+    Add the main sensor arch if the user has specifically enabled it, or if a sensor
+    requires it for mounting
   -->
-  <xacro:property name="topbar_needed_realsense" value="$(arg realsense_enabled)" />
-  <xacro:if value="${topbar_needed_realsense}">
-    <xacro:sensor_arch prefix="" parent="top_plate_link">
-      <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14"/>
-    </xacro:sensor_arch>
+  <xacro:property name="sensorbar_user_enabled"     value="$(arg sensor_arch)" />
+  <xacro:property name="sensorbar_needed_realsense" value="$(arg realsense_enabled)" />
+  <xacro:property name="sensorbar_needed_lidar"     value="$(arg laser_3d_enabled)" />
+  <xacro:if value="${sensorbar_needed_realsense or sensorbar_user_enabled or sensorbar_needed_lidar}">
+    <xacro:sensor_arch prefix="" parent="top_plate_link" size="$(arg sensor_arch_height)">
+        <origin xyz="$(optenv HUSKY_SENSOR_ARCH_OFFSET 0 0 0)" rpy="$(optenv HUSKY_SENSOR_ARCH_RPY 0 0 0)"/>
+      </xacro:sensor_arch>
   </xacro:if>
 
-  <!-- add the intel realsense to the topbar if needed -->
+  <!-- add the intel realsense to the sensor arch if needed -->
   <xacro:if value="$(arg realsense_enabled)">
     <link name="realsense_mountpoint"/>
     <joint name="realsense_mountpoint_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 -3.14159" />
+      <origin xyz="$(arg realsense_xyz)" rpy="$(arg realsense_rpy)" />
       <parent link="$(arg realsense_mount)"/>
       <child link="realsense_mountpoint" />
     </joint>
     <xacro:intel_realsense_mount prefix="camera" topic="realsense" parent_link="realsense_mountpoint"/>
+  </xacro:if>
+
+  <!--
+    Add the 3d laser to the sensor arch if needed
+  -->
+  <xacro:if value="$(arg laser_3d_enabled)">
+    <xacro:vlp16_mount prefix="" parent_link="sensor_arch_mount_link" topic="$(optenv HUSKY_LASER_3D_TOPIC points)">
+      <origin xyz="$(arg laser_3d_xyz)" rpy="$(arg laser_3d_rpy)" />
+    </xacro:vlp16_mount>
   </xacro:if>
 
   <gazebo>


### PR DESCRIPTION
Refactor the Husky accessories so they work in a manner more similar to the other platforms:
1. Launch all accessories from an installed accessories.launch -- this prevents needing to re-run `husky_bringup install` every time envars change or devices are added & removed
2. Re-add support for the `CPR_URDF_EXTRAS` envar needed for GPS-Nav
3. Re-add support for secondary LMS1xx lidar needed for ARK
4. Re-add support for the VLP-16 3D lidar

Currently I'm using the same file-based triggers for the launches, but I mayswap that out for dedicated envars instead to get even closer to the other platforms.
Currently untested, additional changes may be needed.