### PR TITLE
predict odom->base_link tf to current time

### DIFF
--- a/husky_control/config/localization.yaml
+++ b/husky_control/config/localization.yaml
@@ -4,6 +4,8 @@ world_frame: odom
 
 two_d_mode: true
 
+predict_to_current_time: true
+
 frequency: 50
 
 odom0: husky_velocity_controller/odom


### PR DESCRIPTION
This is required for predicting map->odom tf (which itself requires odom->base_link tf). Without this, robot_localization will constantly complain about the odom->base_link not being available at the requested time. 

Other than that, it shouldn't affect anything else