### PR TITLE
Port husky hardware to galactic

### DIFF
--- a/husky_base/CHANGELOG.rst
+++ b/husky_base/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package husky_base
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.0 (2021-11-07)
+------------------
 * Initial Gazebo Classic changes.
 * Updates to use ros2_control.
 * [husky_base] Fixed comparison warnings.

--- a/husky_base/CHANGELOG.rst
+++ b/husky_base/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package husky_base
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Initial Gazebo Classic changes.
+* Updates to use ros2_control.
+* [husky_base] Fixed comparison warnings.
+* [husky_base] Fixed logging variable order.
+* [husky_base] Populated hardware states and removed joints struct.
+* Initial attempt at ros2_control.
+* [husky_base] Updated horizon_legacy library for C++11.
+* [husky_base] Linting changes to horizon_legacy library.
+* Contributors: Tony Baltovski
+
 0.4.4 (2020-08-13)
 ------------------
 * Removed Paul Bovbel as maintainer.

--- a/husky_base/include/husky_base/husky_hardware.hpp
+++ b/husky_base/include/husky_base/husky_hardware.hpp
@@ -5,15 +5,12 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/types/hardware_interface_status_values.hpp"
 #include "hardware_interface/visibility_control.h"
 #include "rclcpp/macros.hpp"
-
 
 #include <chrono>
 
@@ -26,14 +23,13 @@ using namespace std::chrono_literals;
 namespace husky_base
 {
 
-class HuskyHardware
-: public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+class HuskyHardware : public hardware_interface::SystemInterface
 {
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(HuskyHardware)
 
   HARDWARE_INTERFACE_PUBLIC
-  hardware_interface::return_type configure(const hardware_interface::HardwareInfo & info) override;
+  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
   HARDWARE_INTERFACE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
@@ -42,10 +38,10 @@ public:
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
   HARDWARE_INTERFACE_PUBLIC
-  hardware_interface::return_type start() override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
   HARDWARE_INTERFACE_PUBLIC
-  hardware_interface::return_type stop() override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
   HARDWARE_INTERFACE_PUBLIC
   hardware_interface::return_type read() override;

--- a/husky_base/package.xml
+++ b/husky_base/package.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>husky_base</name>
-  <version>0.4.4</version>
+  <version>1.0.0</version>
   <description>Clearpath Husky robot driver</description>
 
   <author email="mpurvis@clearpathrobotics.com">Mike Purvis</author>

--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -166,17 +166,16 @@ namespace husky_base
   }
 
 
-hardware_interface::return_type HuskyHardware::configure(
-  const hardware_interface::HardwareInfo & info)
+CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & info)
 {
-  if (configure_default(info) != hardware_interface::return_type::OK)
+  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
   {
-    return hardware_interface::return_type::ERROR;
+    return CallbackReturn::ERROR;
   }
 
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Name: %s", info_.name.c_str());
 
-  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Number of Joints %u", info_.joints.size());
+  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Number of Joints %zu", info_.joints.size());
 
   hw_start_sec_ = std::stod(info_.hardware_parameters["hw_start_duration_sec"]);
   hw_stop_sec_ = std::stod(info_.hardware_parameters["hw_stop_duration_sec"]);
@@ -204,9 +203,9 @@ hardware_interface::return_type HuskyHardware::configure(
     {
       RCLCPP_FATAL(
         rclcpp::get_logger(HW_NAME),
-        "Joint '%s' has %d command interfaces found. 1 expected.", joint.name.c_str(),
+        "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
         joint.command_interfaces.size());
-      return hardware_interface::return_type::ERROR;
+      return CallbackReturn::ERROR;
     }
 
     if (joint.command_interfaces[0].name != hardware_interface::HW_IF_VELOCITY)
@@ -215,26 +214,26 @@ hardware_interface::return_type HuskyHardware::configure(
         rclcpp::get_logger(HW_NAME),
         "Joint '%s' have %s command interfaces found. '%s' expected.", joint.name.c_str(),
         joint.command_interfaces[0].name.c_str(), hardware_interface::HW_IF_VELOCITY);
-      return hardware_interface::return_type::ERROR;
+      return CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces.size() != 2)
     {
       RCLCPP_FATAL(
         rclcpp::get_logger(HW_NAME),
-        "Joint '%s' has %d state interface. 2 expected.", joint.name.c_str(),
+        "Joint '%s' has %zu state interface. 2 expected.", joint.name.c_str(),
         joint.state_interfaces.size());
-      return hardware_interface::return_type::ERROR;
+      return CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
     {
       RCLCPP_FATAL(
         rclcpp::get_logger(HW_NAME),
-        "Joint '%s' have '%s' as first state interface. '%s' and '%s' expected.",
+        "Joint '%s' have '%s' as first state interface. '%s' expected.",
         joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
         hardware_interface::HW_IF_POSITION);
-      return hardware_interface::return_type::ERROR;
+      return CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces[1].name != hardware_interface::HW_IF_VELOCITY)
@@ -243,12 +242,11 @@ hardware_interface::return_type HuskyHardware::configure(
         rclcpp::get_logger(HW_NAME),
         "Joint '%s' have '%s' as second state interface. '%s' expected.", joint.name.c_str(),
         joint.state_interfaces[1].name.c_str(), hardware_interface::HW_IF_VELOCITY);
-      return hardware_interface::return_type::ERROR;
+      return CallbackReturn::ERROR;
     }
   }
 
-  status_ = hardware_interface::status::CONFIGURED;
-  return hardware_interface::return_type::OK;
+  return CallbackReturn::SUCCESS;
 }
 
 std::vector<hardware_interface::StateInterface> HuskyHardware::export_state_interfaces()
@@ -278,7 +276,7 @@ std::vector<hardware_interface::CommandInterface> HuskyHardware::export_command_
   return command_interfaces;
 }
 
-hardware_interface::return_type HuskyHardware::start()
+CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Starting ...please wait...");
 
@@ -301,14 +299,12 @@ hardware_interface::return_type HuskyHardware::start()
     }
   }
 
-  status_ = hardware_interface::status::STARTED;
-
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System Successfully started!");
 
-  return hardware_interface::return_type::OK;
+  return CallbackReturn::SUCCESS;
 }
 
-hardware_interface::return_type HuskyHardware::stop()
+CallbackReturn HuskyHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Stopping ...please wait...");
 
@@ -319,11 +315,9 @@ hardware_interface::return_type HuskyHardware::stop()
       rclcpp::get_logger(HW_NAME), "%.1f seconds left...", hw_stop_sec_ - i);
   }
 
-  status_ = hardware_interface::status::STOPPED;
-
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System successfully stopped!");
 
-  return hardware_interface::return_type::OK;
+  return CallbackReturn::SUCCESS;
 }
 
 hardware_interface::return_type HuskyHardware::read()

--- a/husky_control/CHANGELOG.rst
+++ b/husky_control/CHANGELOG.rst
@@ -2,6 +2,21 @@
 Changelog for package husky_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Initial Gazebo Classic changes.
+* [husky_control] Added basic localization config.
+* [husky_control] Disabled interactive_marker_twist_server for now.
+* Removed missing packages in ROS2.
+* [husky_control] Removed multimaster_launch.
+* [husky_control] Added teleop launch.
+* [husky_control] Update control rate to 10Hz.
+* Updates to use ros2_control.
+* [husky_control] Updated CMakeLists.txt.
+* Initial attempt at ros2_control.
+* Add the link_name parameter to fix the interactive markers in rviz
+* Contributors: Chris Iverach-Brereton, Tony Baltovski
+
 0.4.4 (2020-08-13)
 ------------------
 * clearer wording

--- a/husky_control/CHANGELOG.rst
+++ b/husky_control/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package husky_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.0 (2021-11-07)
+------------------
 * Initial Gazebo Classic changes.
 * [husky_control] Added basic localization config.
 * [husky_control] Disabled interactive_marker_twist_server for now.

--- a/husky_control/package.xml
+++ b/husky_control/package.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>husky_control</name>
-  <version>0.4.4</version>
+  <version>1.0.0</version>
   <description>Clearpath Husky controller configurations</description>
 
   <author email="mpurvis@clearpathrobotics.com">Mike Purvis</author>

--- a/husky_description/CHANGELOG.rst
+++ b/husky_description/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package husky_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.0 (2021-11-07)
+------------------
 * Initial Gazebo Classic changes.
 * [husky_description] Updated serial port.
 * Updates to use ros2_control.

--- a/husky_description/CHANGELOG.rst
+++ b/husky_description/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog for package husky_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Initial Gazebo Classic changes.
+* [husky_description] Updated serial port.
+* Updates to use ros2_control.
+* Initial attempt at ros2_control.
+* Update husky.urdf.xacro (`#169 <https://github.com/husky/husky/issues/169>`_)
+  Fix Failed to build tree: child link [base_laser_mount] of joint [laser_mount_joint] not found error.
+  As found on https://answers.ros.org/question/354219/failed-to-build-tree-child-link-base_laser_mount-of-joint-laser_mount_joint-not-found/
+* Contributors: Guido Sanchez, Tony Baltovski
+
 0.4.4 (2020-08-13)
 ------------------
 * Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.

--- a/husky_description/package.xml
+++ b/husky_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>husky_description</name>
-  <version>0.4.4</version>
+  <version>1.0.0</version>
   <description>Clearpath Husky URDF description</description>
 
   <author email="rgariepy@clearpathrobotics.com">Ryan Gariepy</author>

--- a/husky_gazebo/CHANGELOG.rst
+++ b/husky_gazebo/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package husky_gazebo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Initial Gazebo Classic changes.
+* Added COLCON_IGNORE for certian packages.
+* Contributors: Tony Baltovski
+
 0.4.4 (2020-08-13)
 ------------------
 * Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.

--- a/husky_gazebo/CHANGELOG.rst
+++ b/husky_gazebo/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package husky_gazebo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.0 (2021-11-07)
+------------------
 * Initial Gazebo Classic changes.
 * Added COLCON_IGNORE for certian packages.
 * Contributors: Tony Baltovski

--- a/husky_gazebo/package.xml
+++ b/husky_gazebo/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>husky_gazebo</name>
-  <version>0.4.4</version>
+  <version>1.0.0</version>
   <description>Clearpath Husky Simulator bringup</description>
 
   <author email="rgariepy@clearpathrobotics.com">Ryan Gariepy</author>

--- a/husky_msgs/CHANGELOG.rst
+++ b/husky_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package husky_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.0 (2021-11-07)
+------------------
 * [husky_msgs] Updated husky_msgs for ROS2.
 * Contributors: Tony Baltovski
 

--- a/husky_msgs/CHANGELOG.rst
+++ b/husky_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package husky_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [husky_msgs] Updated husky_msgs for ROS2.
+* Contributors: Tony Baltovski
+
 0.4.4 (2020-08-13)
 ------------------
 * Removed Paul Bovbel as maintainer.

--- a/husky_msgs/package.xml
+++ b/husky_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>husky_msgs</name>
-  <version>0.4.4</version>
+  <version>1.0.0</version>
   <description>Messages for Clearpath Husky</description>
   <author email="paul@bovbel.com">Paul Bovbel</author>
   <maintainer email="tbaltovski@clearpathrobotics.com">Tony Baltovski</maintainer>

--- a/husky_viz/CHANGELOG.rst
+++ b/husky_viz/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package husky_viz
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [husky_viz] Removed tests.
+* [husky_viz] Switched to depend on rviz2.
+* Removed missing packages in ROS2.
+* Updates to use ros2_control.
+* Added COLCON_IGNORE for certian packages.
+* Contributors: Tony Baltovski
+
 0.4.4 (2020-08-13)
 ------------------
 * Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.

--- a/husky_viz/CHANGELOG.rst
+++ b/husky_viz/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package husky_viz
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.0 (2021-11-07)
+------------------
 * [husky_viz] Removed tests.
 * [husky_viz] Switched to depend on rviz2.
 * Removed missing packages in ROS2.

--- a/husky_viz/package.xml
+++ b/husky_viz/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>husky_viz</name>
-  <version>0.4.4</version>
+  <version>1.0.0</version>
   <description>Visualization configuration for Clearpath Husky</description>
 
   <author email="rgariepy@clearpathrobotics.com">Ryan Gariepy</author>


### PR DESCRIPTION
**Note:** this needs a new branch, e.g., `galactic-devel`

Port is done according to [this manual](http://control.ros.org/ros2_control/hardware_interface/doc/hardware_components_userdoc.html#migration-from-foxy-to-galactic).

The hardware interface is compatible with current galactic and rolling version of ros2_control.

We are using gazebo simulation for a demo in [smacc2](https://github.com/robosoft-ai/SMACC2).
