### PR TITLE
Fix 🛠: remove copied example code

### DIFF
--- a/husky_base/include/husky_base/husky_hardware.hpp
+++ b/husky_base/include/husky_base/husky_hardware.hpp
@@ -61,7 +61,6 @@ private:
   std::string serial_port_;
   double polling_timeout_;
   double wheel_diameter_, max_accel_, max_speed_;
-  double hw_start_sec_, hw_stop_sec_;
 
   // Store the command for the robot
   std::vector<double> hw_commands_;

--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -177,8 +177,6 @@ CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & i
 
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Number of Joints %zu", info_.joints.size());
 
-  hw_start_sec_ = std::stod(info_.hardware_parameters["hw_start_duration_sec"]);
-  hw_stop_sec_ = std::stod(info_.hardware_parameters["hw_stop_duration_sec"]);
   hw_states_position_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_states_position_offset_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_states_velocity_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
@@ -278,15 +276,6 @@ std::vector<hardware_interface::CommandInterface> HuskyHardware::export_command_
 
 CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Starting ...please wait...");
-
-  for (auto i = 0; i <= hw_start_sec_; i++)
-  {
-    rclcpp::sleep_for(std::chrono::seconds(1));
-    RCLCPP_INFO(
-      rclcpp::get_logger(HW_NAME), "%.1f seconds left...", hw_start_sec_ - i);
-  }
-
   // set some default values
   for (auto i = 0u; i < hw_states_position_.size(); i++)
   {
@@ -306,15 +295,6 @@ CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*prev
 
 CallbackReturn HuskyHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Stopping ...please wait...");
-
-  for (auto i = 0u; i <= hw_stop_sec_; i++)
-  {
-    rclcpp::sleep_for(std::chrono::seconds(1));
-    RCLCPP_INFO(
-      rclcpp::get_logger(HW_NAME), "%.1f seconds left...", hw_stop_sec_ - i);
-  }
-
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System successfully stopped!");
 
   return CallbackReturn::SUCCESS;

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -193,8 +193,6 @@
     <ros2_control name="husky_hardware" type="system">
       <hardware>
         <plugin>husky_base/HuskyHardware</plugin>
-        <param name="hw_start_duration_sec">2.0</param>
-        <param name="hw_stop_duration_sec">3.0</param>
         <param name="wheel_diameter">0.3302</param>
         <param name="max_accel">5.0</param>
         <param name="max_speed">1.0</param>


### PR DESCRIPTION
This code seems to have no function for husky-robots but that is rather copy-paste relict:

- [parameters](https://github.com/ros-controls/ros2_control_demos/blob/37b3338b22ce99200791b191df647256d51f233e/ros2_control_demo_hardware/src/rrbot_system_position_only.cpp#L36-L37)
- [on_activate](https://github.com/ros-controls/ros2_control_demos/blob/37b3338b22ce99200791b191df647256d51f233e/ros2_control_demo_hardware/src/rrbot_system_position_only.cpp#L143-L149)
- [on_deactivate](https://github.com/ros-controls/ros2_control_demos/blob/37b3338b22ce99200791b191df647256d51f233e/ros2_control_demo_hardware/src/rrbot_system_position_only.cpp#L168-L174)

If I missed the idea/issue here, feel free to close the PR.
