### PR TITLE
Update teleop_ps4.yaml

### DIFF
--- a/husky_control/config/teleop_ps4.yaml
+++ b/husky_control/config/teleop_ps4.yaml
@@ -65,4 +65,3 @@ teleop_twist_joy:
 joy_node:
   deadzone: 0.1
   autorepeat_rate: 20
-  dev: /dev/input/ps4


### PR DESCRIPTION
The teleop_ps4.yaml file that is loaded by teleop.launch overrides the dev option within the joy_dev. The launch file gives the impression that passing in a joy_dev argument will let us override the default option; however, whatever option we pass in is overwritten by the yaml file (because of the last line in the yaml file). Our PS4 controller on our simulation computer uses a different port than in the yaml file and will not run with the included launch file. We had to create our own launch and yaml files to fix this issue.

Command: roslaunch husky_control husky_teleop.launch joy_dev:='/dev/input/js0'
Expected behaviour: The joy_node will use the PS4 controller located at '/dev/input/js0'
Experienced behaviour: The joy_node tries to find a PS4 controller at '/dev/input/ds4x' on the Kinetic branch or '/dev/input/ps4' on the Melodic branch