### PR TITLE
Check launch file only if testing

### DIFF
--- a/husky_control/CMakeLists.txt
+++ b/husky_control/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(husky_control)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin REQUIRED)
 
 catkin_package()
 
-roslaunch_add_file_check(launch)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()
 
 install(DIRECTORY config launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/husky_description/CMakeLists.txt
+++ b/husky_description/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(husky_description)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin REQUIRED)
 
 catkin_package()
 
-roslaunch_add_file_check(launch)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()
 
 install(
   DIRECTORY launch meshes urdf

--- a/husky_navigation/CMakeLists.txt
+++ b/husky_navigation/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(husky_navigation)
 
-find_package(catkin REQUIRED roslaunch)
+find_package(catkin REQUIRED)
 
 catkin_package()
 
-roslaunch_add_file_check(launch)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()
 
 install(
   DIRECTORY config launch maps

--- a/husky_viz/CMakeLists.txt
+++ b/husky_viz/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(husky_viz)
 
-find_package(catkin REQUIRED COMPONENTS roslaunch)
+find_package(catkin REQUIRED)
 
 catkin_package()
 
-roslaunch_add_file_check(launch)
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()
 
 install(
   DIRECTORY launch rviz


### PR DESCRIPTION
When building husky_control, husky_description, husky_navigation or husky_viz without tests, CMake fails as it does not find `catkin_run_tests_target` command. This patch adds conditions to fix this problem.