### PR TITLE
Update DiffDriveController params

### DIFF
--- a/husky_control/config/control.yaml
+++ b/husky_control/config/control.yaml
@@ -10,7 +10,11 @@ husky_velocity_controller:
   pose_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.03]
   twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.03]
   cmd_vel_timeout: 0.25
+  velocity_rolling_window_size: 2
 
+  # Base frame_id
+  base_frame_id: base_link
+  
   # Odometry fused with IMU is published by robot_localization, so
   # no need to publish a TF based on encoders alone.
   enable_odom_tf: false

--- a/husky_control/config/control.yaml
+++ b/husky_control/config/control.yaml
@@ -10,17 +10,10 @@ husky_velocity_controller:
   pose_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.03]
   twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.03]
   cmd_vel_timeout: 0.25
-  velocity_rolling_window_size: 2
-
-  # Base frame_id
-  base_frame_id: base_link
 
   # Odometry fused with IMU is published by robot_localization, so
   # no need to publish a TF based on encoders alone.
   enable_odom_tf: false
-
-  # Husky hardware provides wheel velocities
-  estimate_velocity_from_position: false
 
   # Wheel separation and radius multipliers
   wheel_separation_multiplier: 1.875 # default: 1.0


### PR DESCRIPTION
- Remove `estimate_velocity_from_position: false` because it does not exist as a param in `DiffDriveController`, or anywhere in `ros-controllers`
- Remove `base_frame_id: base_link` because the default value of `base_frame_id` is already `base_link`, as per http://wiki.ros.org/diff_drive_controller
- Remove `velocity_rolling_window_size: 2` so `velocity_rolling_window_size` can take on the default value of 10. A higher value reduces the amount of noise in the odometry, as per: https://docs.google.com/document/d/1x1HOtLs9Z9jfuKdtSMM_YWOrWM4p08LJVt6vQVohVWI/edit#