### PR TITLE
Realsense will no longer add the Sensor Arch

### DIFF
--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -54,7 +54,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="realsense_enabled" default="$(optenv HUSKY_REALSENSE_ENABLED 0)" />
   <xacro:arg name="realsense_xyz" default="$(optenv HUSKY_REALSENSE_XYZ 0 0 0)" />
   <xacro:arg name="realsense_rpy" default="$(optenv HUSKY_REALSENSE_RPY 0 0 0)" />
-  <xacro:arg name="realsense_mount" default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME sensor_arch_mount_link)" />
+  <xacro:arg name="realsense_mount" default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME top_plate_link)" />
 
   <xacro:property name="husky_front_bumper_extend" value="$(optenv HUSKY_FRONT_BUMPER_EXTEND 0)" />
   <xacro:property name="husky_rear_bumper_extend" value="$(optenv HUSKY_REAR_BUMPER_EXTEND 0)" />
@@ -210,10 +210,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     Add the main sensor arch if the user has specifically enabled it, or if a sensor
     requires it for mounting
   -->
-  <xacro:property name="sensorbar_user_enabled"     value="$(arg sensor_arch)" />
-  <xacro:property name="sensorbar_needed_realsense" value="$(arg realsense_enabled)" />
-  <xacro:property name="sensorbar_needed_lidar"     value="$(arg laser_3d_enabled)" />
-  <xacro:if value="${sensorbar_needed_realsense or sensorbar_user_enabled or sensorbar_needed_lidar}">
+  <xacro:if value="$(arg sensor_arch)">
     <xacro:sensor_arch prefix="" parent="top_plate_link" size="$(arg sensor_arch_height)">
         <origin xyz="$(optenv HUSKY_SENSOR_ARCH_OFFSET 0 0 0)" rpy="$(optenv HUSKY_SENSOR_ARCH_RPY 0 0 0)"/>
       </xacro:sensor_arch>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -144,7 +144,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <link name="imu_link"/>
   <joint name="imu_joint" type="fixed">
     <origin xyz="$(optenv HUSKY_IMU_XYZ 0.19 0 0.149)" rpy="$(optenv HUSKY_IMU_RPY 0 -1.5708 3.1416)" />
-    <parent link="base_link" />
+    <parent link="$(optenv HUSKY_IMU_PARENT base_link)" />
     <child link="imu_link" />
   </joint>
   <gazebo reference="imu_link">


### PR DESCRIPTION
By enabling the HUSKY_REALSENSE_ENABLE variable, the sensor_arch would be added to the URDF making it impossible to enable the realsense using environment variables if the sensor arch is not being used. 