### PR TITLE
Small fixes to make repository easier to used with other packages

### DIFF
--- a/husky_control/package.xml
+++ b/husky_control/package.xml
@@ -16,7 +16,7 @@
   <depend>husky_description</depend>
   <!-- <depend>interactive_marker_twist_server</depend> -->
   <depend>diff_drive_controller</depend>
-  <depend>joint_state_controller</depend>
+  <depend>joint_state_broadcaster/depend>
   <depend>joint_trajectory_controller</depend>
   <depend>joy</depend>
   <!-- <depend>multimaster_launch</depend> -->


### PR DESCRIPTION
The PR corrects `ament_cmake` dependency and modernizes the code by switching Boost static assert (`BOOST_STATIC_ASSERT_MSG`) to  `static_assert` from standard library.