### PR TITLE
Define using in local namespace which was defined globally by ros2_control

### DIFF
--- a/husky_base/include/husky_base/husky_hardware.hpp
+++ b/husky_base/include/husky_base/husky_hardware.hpp
@@ -29,7 +29,7 @@ public:
   RCLCPP_SHARED_PTR_DEFINITIONS(HuskyHardware)
 
   HARDWARE_INTERFACE_PUBLIC
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
   HARDWARE_INTERFACE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
@@ -38,10 +38,10 @@ public:
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
   HARDWARE_INTERFACE_PUBLIC
-  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
   HARDWARE_INTERFACE_PUBLIC
-  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
   HARDWARE_INTERFACE_PUBLIC
   hardware_interface::return_type read() override;

--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -47,8 +47,6 @@ namespace
 
 namespace husky_base
 {
-  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
-
   static const std::string HW_NAME = "HuskyHardware";
 
   /**
@@ -168,11 +166,11 @@ namespace husky_base
   }
 
 
-CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & info)
+hardware_interface::CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & info)
 {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
   {
-    return CallbackReturn::ERROR;
+    return hardware_interface::CallbackReturn::ERROR;
   }
 
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "Name: %s", info_.name.c_str());
@@ -205,7 +203,7 @@ CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & i
         rclcpp::get_logger(HW_NAME),
         "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
         joint.command_interfaces.size());
-      return CallbackReturn::ERROR;
+      return hardware_interface::CallbackReturn::ERROR;
     }
 
     if (joint.command_interfaces[0].name != hardware_interface::HW_IF_VELOCITY)
@@ -214,7 +212,7 @@ CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & i
         rclcpp::get_logger(HW_NAME),
         "Joint '%s' have %s command interfaces found. '%s' expected.", joint.name.c_str(),
         joint.command_interfaces[0].name.c_str(), hardware_interface::HW_IF_VELOCITY);
-      return CallbackReturn::ERROR;
+      return hardware_interface::CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces.size() != 2)
@@ -223,7 +221,7 @@ CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & i
         rclcpp::get_logger(HW_NAME),
         "Joint '%s' has %zu state interface. 2 expected.", joint.name.c_str(),
         joint.state_interfaces.size());
-      return CallbackReturn::ERROR;
+      return hardware_interface::CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
@@ -233,7 +231,7 @@ CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & i
         "Joint '%s' have '%s' as first state interface. '%s' expected.",
         joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
         hardware_interface::HW_IF_POSITION);
-      return CallbackReturn::ERROR;
+      return hardware_interface::CallbackReturn::ERROR;
     }
 
     if (joint.state_interfaces[1].name != hardware_interface::HW_IF_VELOCITY)
@@ -242,11 +240,11 @@ CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & i
         rclcpp::get_logger(HW_NAME),
         "Joint '%s' have '%s' as second state interface. '%s' expected.", joint.name.c_str(),
         joint.state_interfaces[1].name.c_str(), hardware_interface::HW_IF_VELOCITY);
-      return CallbackReturn::ERROR;
+      return hardware_interface::CallbackReturn::ERROR;
     }
   }
 
-  return CallbackReturn::SUCCESS;
+  return hardware_interface::CallbackReturn::SUCCESS;
 }
 
 std::vector<hardware_interface::StateInterface> HuskyHardware::export_state_interfaces()
@@ -276,7 +274,7 @@ std::vector<hardware_interface::CommandInterface> HuskyHardware::export_command_
   return command_interfaces;
 }
 
-CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+hardware_interface::CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   // set some default values
   for (auto i = 0u; i < hw_states_position_.size(); i++)
@@ -292,14 +290,14 @@ CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*prev
 
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System Successfully started!");
 
-  return CallbackReturn::SUCCESS;
+  return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-CallbackReturn HuskyHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+hardware_interface::CallbackReturn HuskyHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger(HW_NAME), "System successfully stopped!");
 
-  return CallbackReturn::SUCCESS;
+  return hardware_interface::CallbackReturn::SUCCESS;
 }
 
 hardware_interface::return_type HuskyHardware::read()

--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -47,6 +47,8 @@ namespace
 
 namespace husky_base
 {
+  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
   static const std::string HW_NAME = "HuskyHardware";
 
   /**


### PR DESCRIPTION
This PR fixes regression introduced it ros-controls/ros2_control/pull/673.
It is fix for rolling, but it should also work on galactic.
