### PR TITLE
Add missing CallbackReturn definition

### DIFF
--- a/husky_base/include/husky_base/husky_hardware.hpp
+++ b/husky_base/include/husky_base/husky_hardware.hpp
@@ -22,6 +22,7 @@ using namespace std::chrono_literals;
 
 namespace husky_base
 {
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 class HuskyHardware : public hardware_interface::SystemInterface
 {


### PR DESCRIPTION
Fixes
```
/ros2_workspace/src/husky/husky_base/src/husky_hardware.cpp:169:1: error: ‘CallbackReturn’ does not name a type
  169 | CallbackReturn HuskyHardware::on_init(const hardware_interface::HardwareInfo & info)
      | ^~~~~~~~~~~~~~
/ros2_workspace/src/husky/husky_base/src/husky_hardware.cpp:277:1: error: ‘CallbackReturn’ does not name a type
  277 | CallbackReturn HuskyHardware::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
      | ^~~~~~~~~~~~~~
/ros2_workspace/src/husky/husky_base/src/husky_hardware.cpp:296:1: error: ‘CallbackReturn’ does not name a type
  296 | CallbackReturn HuskyHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
      | ^~~~~~~~~~~~~~
```