### PR TITLE
added gazebo_ros2_control dependency

### DIFF
--- a/husky_gazebo/package.xml
+++ b/husky_gazebo/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>husky_control</exec_depend>
   <exec_depend>husky_description</exec_depend>
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>gazebo_ros2_control</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/husky_gazebo/package.xml
+++ b/husky_gazebo/package.xml
@@ -23,10 +23,11 @@
   <depend>xacro</depend>
 
   <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>husky_control</exec_depend>
   <exec_depend>husky_description</exec_depend>
   <exec_depend>ros2launch</exec_depend>
-  <exec_depend>gazebo_ros2_control</exec_depend>
+  
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/husky_gazebo/package.xml
+++ b/husky_gazebo/package.xml
@@ -27,7 +27,6 @@
   <exec_depend>husky_control</exec_depend>
   <exec_depend>husky_description</exec_depend>
   <exec_depend>ros2launch</exec_depend>
-  
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Required for connecting ros2_control controller to gazebo.