### PR TITLE
Uncomment dependency on husky_bringup

### DIFF
--- a/husky_robot/package.xml
+++ b/husky_robot/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>husky_base</exec_depend>
-  <!-- <exec_depend>husky_bringup</exec_depend> -->
+  <exec_depend>husky_bringup</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
In light of `husky_bringup` being completed and released, it makes sense to re-enable this dependency.