### PR TITLE
Add keyboard teleoperation functionality to `husky_control` package

### DIFF
--- a/husky_control/CHANGELOG.rst
+++ b/husky_control/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package husky_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.5 (2022-08-08)
+------------------
+* Add keyboard teleoperation functionality.
+* Contributors: Tinker Twins (Chinmay Samak & Tanmay Samak)
+
 0.6.4 (2022-06-16)
 ------------------
 

--- a/husky_control/CMakeLists.txt
+++ b/husky_control/CMakeLists.txt
@@ -15,6 +15,11 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(launch)
 endif()
 
+catkin_install_python(PROGRAMS
+  scripts/teleop_keyboard.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 install(DIRECTORY config launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/husky_control/CMakeLists.txt
+++ b/husky_control/CMakeLists.txt
@@ -6,7 +6,9 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
 )
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS rospy geometry_msgs
+)
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)

--- a/husky_control/CMakeLists.txt
+++ b/husky_control/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(husky_control)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  geometry_msgs
+)
 
 catkin_package()
 

--- a/husky_control/launch/teleop_keyboard.launch
+++ b/husky_control/launch/teleop_keyboard.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<launch>
+
+  <!-- Husky Keyboard Teleoperation -->
+  <node pkg="husky_control" type="teleop_keyboard.py" name="teleop_keyboard" output="screen"/>
+
+</launch>

--- a/husky_control/package.xml
+++ b/husky_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>husky_control</name>
-  <version>0.6.4</version>
+  <version>0.6.5</version>
   <description>Clearpath Husky controller configurations</description>
 
   <author email="paul@bovbel.com">Paul Bovbel</author>

--- a/husky_control/package.xml
+++ b/husky_control/package.xml
@@ -15,8 +15,10 @@
   <url type="repository">https://github.com/husky/husky</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>roslaunch</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>geometry_msgs</build_depend>
 
   <run_depend>husky_description</run_depend>
   <run_depend>interactive_marker_twist_server</run_depend>

--- a/husky_control/package.xml
+++ b/husky_control/package.xml
@@ -33,6 +33,8 @@
   <run_depend>controller_manager</run_depend>
   <run_depend>teleop_twist_joy</run_depend>
   <run_depend>twist_mux</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>geometry_msgs</run_depend>
 
   <export>
   </export>

--- a/husky_control/package.xml
+++ b/husky_control/package.xml
@@ -15,6 +15,7 @@
   <url type="repository">https://github.com/husky/husky</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  
   <build_depend>roslaunch</build_depend>
 
   <run_depend>husky_description</run_depend>

--- a/husky_control/scripts/LICENSE
+++ b/husky_control/scripts/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2011, Willow Garage, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/husky_control/scripts/LICENSE
+++ b/husky_control/scripts/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2011, Willow Garage, Inc.
+Copyright (c) 2022, Tinker Twins
 
 All rights reserved.
 

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -33,3 +33,15 @@ NOTE: Press keys within this terminal
 error = """
 ERROR: Communication failed!
 """
+
+def get_key():
+    if os.name == 'nt':
+      return msvcrt.getch()
+    tty.setraw(sys.stdin.fileno())
+    rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
+    if rlist:
+        key = sys.stdin.read(1)
+    else:
+        key = ''
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+    return key

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -54,3 +54,7 @@ def constrain(input, low, high):
     else:
       input = input
     return input
+
+def bound_lin_vel(lin_vel_cmd):
+    lin_vel_cmd = constrain(lin_vel_cmd, -LIN_VEL_LIMIT, LIN_VEL_LIMIT)
+    return lin_vel_cmd

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -107,6 +107,7 @@ if __name__=="__main__":
 
             cmd_vel_msg = generate_cmd_vel_msg(lin_vel, ang_vel)
             cmd_vel_pub.publish(cmd_vel_msg)
+
     except:
         print(error)
 

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -14,3 +14,22 @@ LIN_VEL_LIMIT = 1.0 # m/s
 ANG_VEL_LIMIT = 2.0 # rads
 LIN_VEL_STEP  = 0.1
 ANG_VEL_STEP  = 0.1
+
+info = """
+----------------------------------------
+Husky Robot Keyboard Teleoperation Panel
+----------------------------------------
+                 W
+             A   S   D
+                 X
+W/S : Increase/decrease linear velocity
+D/A : Increase/decrease angular velocity
+X   : Emergency brake
+Press CTRL+C to quit
+NOTE: Press keys within this terminal
+----------------------------------------
+"""
+
+error = """
+ERROR: Communication failed!
+"""

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -87,3 +87,20 @@ if __name__=="__main__":
 
     try:
         print(info)
+
+        while(1):
+            key = get_key()
+            if key == 'w' :
+                lin_vel = bound_lin_vel(lin_vel + LIN_VEL_STEP)
+            elif key == 's' :
+                lin_vel = bound_lin_vel(lin_vel - LIN_VEL_STEP)
+            elif key == 'a' :
+                ang_vel = bound_ang_vel(ang_vel + ANG_VEL_STEP)
+            elif key == 'd' :
+                ang_vel = bound_ang_vel(ang_vel - ANG_VEL_STEP)
+            elif key == 'x' :
+                lin_vel = 0.0
+                ang_vel = 0.0
+            else:
+                if (key == '\x03'): # CTRL+C
+                    break

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -58,3 +58,7 @@ def constrain(input, low, high):
 def bound_lin_vel(lin_vel_cmd):
     lin_vel_cmd = constrain(lin_vel_cmd, -LIN_VEL_LIMIT, LIN_VEL_LIMIT)
     return lin_vel_cmd
+
+def bound_ang_vel(ang_vel_cmd):
+    ang_vel_cmd = constrain(ang_vel_cmd, -ANG_VEL_LIMIT, ANG_VEL_LIMIT)
+    return ang_vel_cmd

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -109,3 +109,9 @@ if __name__=="__main__":
             cmd_vel_pub.publish(cmd_vel_msg)
     except:
         print(error)
+
+    finally:
+        lin_vel = 0.0
+        ang_vel = 0.0
+        cmd_vel_msg = generate_cmd_vel_msg(lin_vel, ang_vel)
+        cmd_vel_pub.publish(cmd_vel_msg)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -81,3 +81,6 @@ if __name__=="__main__":
 
     rospy.init_node('husky_teleop_keyboard')
     cmd_vel_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=10)
+
+    lin_vel = 0.0
+    ang_vel = 0.0

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -104,3 +104,6 @@ if __name__=="__main__":
             else:
                 if (key == '\x03'): # CTRL+C
                     break
+
+            cmd_vel_msg = generate_cmd_vel_msg(lin_vel, ang_vel)
+            cmd_vel_pub.publish(cmd_vel_msg)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -45,3 +45,12 @@ def get_key():
         key = ''
     termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
     return key
+
+def constrain(input, low, high):
+    if input < low:
+      input = low
+    elif input > high:
+      input = high
+    else:
+      input = input
+    return input

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -9,3 +9,8 @@ else:
   import tty, termios
 
 ################################################################################
+
+LIN_VEL_LIMIT = 1.0 # m/s
+ANG_VEL_LIMIT = 2.0 # rads
+LIN_VEL_STEP  = 0.1
+ANG_VEL_STEP  = 0.1

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -72,3 +72,5 @@ def generate_cmd_vel_msg(lin_vel_cmd, ang_vel_cmd):
     cmd_vel_msg.angular.y = 0.0
     cmd_vel_msg.angular.z = ang_vel_cmd
     return cmd_vel_msg
+
+################################################################################

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -74,3 +74,7 @@ def generate_cmd_vel_msg(lin_vel_cmd, ang_vel_cmd):
     return cmd_vel_msg
 
 ################################################################################
+
+if __name__=="__main__":
+    if os.name != 'nt':
+        settings = termios.tcgetattr(sys.stdin)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -115,3 +115,6 @@ if __name__=="__main__":
         ang_vel = 0.0
         cmd_vel_msg = generate_cmd_vel_msg(lin_vel, ang_vel)
         cmd_vel_pub.publish(cmd_vel_msg)
+
+    if os.name != 'nt':
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -107,3 +107,5 @@ if __name__=="__main__":
 
             cmd_vel_msg = generate_cmd_vel_msg(lin_vel, ang_vel)
             cmd_vel_pub.publish(cmd_vel_msg)
+    except:
+        print(error)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -84,3 +84,6 @@ if __name__=="__main__":
 
     lin_vel = 0.0
     ang_vel = 0.0
+
+    try:
+        print(info)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -78,3 +78,6 @@ def generate_cmd_vel_msg(lin_vel_cmd, ang_vel_cmd):
 if __name__=="__main__":
     if os.name != 'nt':
         settings = termios.tcgetattr(sys.stdin)
+
+    rospy.init_node('husky_teleop_keyboard')
+    cmd_vel_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=10)

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -62,3 +62,13 @@ def bound_lin_vel(lin_vel_cmd):
 def bound_ang_vel(ang_vel_cmd):
     ang_vel_cmd = constrain(ang_vel_cmd, -ANG_VEL_LIMIT, ANG_VEL_LIMIT)
     return ang_vel_cmd
+
+def generate_cmd_vel_msg(lin_vel_cmd, ang_vel_cmd):
+    cmd_vel_msg = Twist()
+    cmd_vel_msg.linear.x  = lin_vel_cmd
+    cmd_vel_msg.linear.y  = 0.0
+    cmd_vel_msg.linear.z  = 0.0
+    cmd_vel_msg.angular.x = 0.0
+    cmd_vel_msg.angular.y = 0.0
+    cmd_vel_msg.angular.z = ang_vel_cmd
+    return cmd_vel_msg

--- a/husky_control/scripts/teleop_keyboard.py
+++ b/husky_control/scripts/teleop_keyboard.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import rospy
+from geometry_msgs.msg import Twist
+import sys, select, os
+if os.name == 'nt':
+  import msvcrt
+else:
+  import tty, termios
+
+################################################################################

--- a/husky_gazebo/launch/realsense.launch
+++ b/husky_gazebo/launch/realsense.launch
@@ -1,3 +1,5 @@
+<?xml version="1.0"?>
+
 <launch>
   <!-- Include poincloud_to_laserscan if simulated realsense is attached -->
   <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="realsense_to_laserscan" output="screen">


### PR DESCRIPTION
## Summay:
Added `teleop_keyboard.py` script and `teleop_keyboard.launch` file to `husky_control` package for enabling convenient teleoperation of Husky robot using standard computer keyboard.

## Usage:
1. Open up a Terminal window and run the following command:
    ```bash
    $ roslaunch husky_gazebo husky_playpen.launch
    ```

2. Open up a new Terminal window (or a new tab in the existing window `CTRL+SHIFT+T`) and run the following command:
    ```bash
    $ roslaunch husky_control teleop_keyboard.launch
    ```

## Demo:
Video demonstration showing keyboard teleoperation of Husky robot in Playpen environment (Gazebo simulation) is available on [YouTube](https://youtu.be/B-4VfZrvVJo).