### PR TITLE
Change namespaces to match imu_filter name defined in control.launch.py

### DIFF
--- a/husky_control/config/imu_filter.yaml
+++ b/husky_control/config/imu_filter.yaml
@@ -1,4 +1,4 @@
-imu_filter_node:
+imu_filter:
   ros__parameters:
     stateless: false
     use_mag: false


### PR DESCRIPTION
Switching our Husky to ROS2, I noticed that a node was publishing a tf-transform 'odom'->'imu_link'. The messages were originated in the IMU-filter, which ignored the provided parameter file due to incorrect naming.