### PR TITLE
Change RIGHT wheel index from 1 to 2.

### DIFF
--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -42,7 +42,7 @@
 
 namespace
 {
-  const uint8_t LEFT = 0, RIGHT = 1;
+  const uint8_t LEFT = 0, RIGHT = 2;
 }
 
 namespace husky_base


### PR DESCRIPTION
Fixes https://github.com/husky/husky/issues/218. The index into `hw_commands_` was incorrect in `husky_hardware.cpp`, which meant the interface was grabbing two left wheel commands, instead of a left and right wheel.

This has been tested on a real Husky running Ubuntu 20.04 Galactic.