### PR TITLE
Add envar support to gazebo GPS plugin reference coordinate

### DIFF
--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -360,8 +360,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       <frameId>base_link</frameId>
       <topicName>navsat/fix</topicName>
       <velocityTopicName>navsat/vel</velocityTopicName>
-      <referenceLatitude>49.9</referenceLatitude>
-      <referenceLongitude>8.9</referenceLongitude>
+      <referenceLatitude>$(optenv DATUM_LAT 49.9)</referenceLatitude>
+      <referenceLongitude>$(optenv DATUM_LON 8.9)</referenceLongitude>
       <referenceHeading>0</referenceHeading>
       <referenceAltitude>0</referenceAltitude>
       <drift>0.0001 0.0001 0.0001</drift>


### PR DESCRIPTION
Use DATUM_LAT and DATUM_LON envars to override the default reference lat/lon for the Gazebo GPS plugin. This addresses a compatibility issue with outdoor nav simulations