### PR TITLE
Rename DATUM_* envars for Gazebo simulation

### DIFF
--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -360,8 +360,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       <frameId>base_link</frameId>
       <topicName>navsat/fix</topicName>
       <velocityTopicName>navsat/vel</velocityTopicName>
-      <referenceLatitude>$(optenv DATUM_LAT 49.9)</referenceLatitude>
-      <referenceLongitude>$(optenv DATUM_LON 8.9)</referenceLongitude>
+      <referenceLatitude>$(optenv GAZEBO_WORLD_LAT 49.9)</referenceLatitude>
+      <referenceLongitude>$(optenv GAZEBO_WORLD_LON 8.9)</referenceLongitude>
       <referenceHeading>0</referenceHeading>
       <referenceAltitude>0</referenceAltitude>
       <drift>0.0001 0.0001 0.0001</drift>


### PR DESCRIPTION
Rename DATUM_* to GAZEBO_WORLD_*. We're separating the datum from the world's origin, and this keeps envars from clobbering each other.

When I made the previous PR to add those envars I misunderstood Steve & Jose's intentions.