### PR TITLE
Add XML declaration to `realsense.launch`

### DIFF
--- a/husky_gazebo/launch/realsense.launch
+++ b/husky_gazebo/launch/realsense.launch
@@ -1,3 +1,5 @@
+<?xml version="1.0"?>
+
 <launch>
   <!-- Include poincloud_to_laserscan if simulated realsense is attached -->
   <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="realsense_to_laserscan" output="screen">


### PR DESCRIPTION
Added XML declaration to `realsense.launch` file (similar to other launch files) so that XML processor of text/code editors or IDEs can parse it as an XML document (rather than a simple text document).