### PR TITLE
Rename husky_empty_world.launch to empty_world.launch

### DIFF
--- a/husky_gazebo/CMakeLists.txt
+++ b/husky_gazebo/CMakeLists.txt
@@ -12,7 +12,7 @@ install(
 )
 
 install(
-  FILES launch/husky_empty_world.launch
+  FILES launch/empty_world.launch
         launch/husky_playpen.launch
         launch/playpen.launch
         launch/realsense.launch
@@ -22,7 +22,7 @@ install(
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(launch/husky_empty_world.launch)
+  roslaunch_add_file_check(launch/empty_world.launch)
   roslaunch_add_file_check(launch/husky_playpen.launch)
   roslaunch_add_file_check(launch/playpen.launch)
   roslaunch_add_file_check(launch/realsense.launch)

--- a/husky_gazebo/launch/empty_world.launch
+++ b/husky_gazebo/launch/empty_world.launch
@@ -2,7 +2,7 @@
 <!--
 Software License Agreement (BSD)
 
-\file      husky_empty_world.launch
+\file      empty_world.launch
 \authors   Paul Bovbel <pbovbel@clearpathrobotics.com, Devon Ash <dash@clearpathrobotics.com>
 \copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
 


### PR DESCRIPTION
This makes Husky more consistent with other platforms and makes it easier to include this launch file in multi-platform scripts, such as those used in outdoornav.