### PR TITLE
Add a scan_topic argument to the gmapping_demo

### DIFF
--- a/husky_navigation/launch/gmapping_demo.launch
+++ b/husky_navigation/launch/gmapping_demo.launch
@@ -25,8 +25,13 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
+  <!-- Arg to remap the scan topic -->
+  <arg name="scan_topic" default="front/scan" />
+   
   <!--- Run gmapping -->
-  <include file="$(find husky_navigation)/launch/gmapping.launch" />
+  <include file="$(find husky_navigation)/launch/gmapping.launch">
+    <arg name="scan_topic" value="$(arg scan_topic)" />
+  </include>
 
   <!--- Run Move Base -->
   <include file="$(find husky_navigation)/launch/move_base.launch" />


### PR DESCRIPTION
This just exposes the gmapping.launch file's argument to the gmapping_demo.launch to make it easier to use non-standard topics.