### PR TITLE
ONAV-957

### DIFF
--- a/husky_description/package.xml
+++ b/husky_description/package.xml
@@ -20,14 +20,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
+  <run_depend>cpr_onav_description</run_depend>
   <run_depend>fath_pivot_mount_description</run_depend>
   <run_depend>flir_camera_description</run_depend>
-  <run_depend>cpr_onav_description</run_depend>
+  <run_depend>lms1xx</run_depend>
   <run_depend>realsense2_description</run_depend>
   <run_depend>urdf</run_depend>
-  <run_depend>xacro</run_depend>
-  <run_depend>lms1xx</run_depend>
   <run_depend>velodyne_description</run_depend>
+  <run_depend>xacro</run_depend>
 
   <export>
   </export>

--- a/husky_description/package.xml
+++ b/husky_description/package.xml
@@ -22,6 +22,7 @@
   <build_depend>roslaunch</build_depend>
   <run_depend>fath_pivot_mount_description</run_depend>
   <run_depend>flir_camera_description</run_depend>
+  <run_depend>cpr_onav_description</run_depend>
   <run_depend>realsense2_description</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -126,10 +126,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="cpr_urdf_extras" default="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
 
   <!-- OutdoorNav -->
-  <xacro:arg name="outdoornav_enabled"         default="$(optenv OUTDOORNAV_ENABLED 0)" />
-  <xacro:arg name="starter_kit_configuration"  default="$(optenv STARTER_KIT_CONFIGURATION 0)" />
-  <xacro:arg name="standard_kit_configuration" default="$(optenv STANDARD_KIT_CONFIGURATION 0)" />
-  <xacro:arg name="custom_configuration"       default="$(optenv CUSTOM_CONFIGURATION 0)" />
+  <xacro:arg name="outdoornav_enabled"       default="$(optenv OUTDOORNAV_ENABLED 0)" />
+  <xacro:arg name="outdoornav_configuration" default="$(optenv OUTDOORNAV_CONFIGURATION standard)" />
 
   <!-- Included URDF/XACRO Files -->
   <xacro:include filename="$(find husky_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
@@ -343,11 +341,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <!-- OutdoorNav URDF Config -->
   <xacro:if value="$(arg outdoornav_enabled)">
     <xacro:include filename="$(find cpr_onav_description)/urdf/outdoornav_description.urdf.xacro" />
-    <xacro:outdoornav_sensors
-      starter_kit_configuration="$(arg starter_kit_configuration)"
-      standard_kit_configuration="$(arg standard_kit_configuration)"
-      custom_configuration="$(arg custom_configuration)" >
-    </xacro:outdoornav_sensors>
+    <xacro:outdoornav_sensors outdoornav_configuration="$(arg outdoornav_configuration)" />
   </xacro:if>
 
   <gazebo>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -125,6 +125,12 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="urdf_extras"     default="$(optenv HUSKY_URDF_EXTRAS empty.urdf)" />
   <xacro:arg name="cpr_urdf_extras" default="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
 
+  <!-- OutdoorNav -->
+  <xacro:arg name="outdoornav_enable"          default="$(optenv OUTDOORNAV_ENABLE 0)" />
+  <xacro:arg name="starter_kit_configuration"  default="$(optenv STARTER_KIT_CONFIGURATION 0)" />
+  <xacro:arg name="standard_kit_configuration" default="$(optenv STANDARD_KIT_CONFIGURATION 0)" />
+  <xacro:arg name="custom_configuration"       default="$(optenv CUSTOM_CONFIGURATION 0)" />
+
   <!-- Included URDF/XACRO Files -->
   <xacro:include filename="$(find husky_description)/urdf/accessories/hokuyo_ust10.urdf.xacro" />
   <xacro:include filename="$(find husky_description)/urdf/accessories/intel_realsense.urdf.xacro"/>
@@ -332,6 +338,16 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <origin xyz="$(arg laser_3d_secondary_xyz)" rpy="$(arg laser_3d_secondary_rpy)" />
       </xacro:VLP-16>
     </xacro:unless>
+  </xacro:if>
+
+  <!-- OutdoorNav URDF Config -->
+  <xacro:if value="$(arg outdoornav_enable)">
+    <xacro:include filename="$(find cpr_onav_description)/urdf/outdoornav_description.urdf.xacro" />
+    <xacro:outdoornav_sensors
+      starter_kit_configuration="$(arg starter_kit_configuration)"
+      standard_kit_configuration="$(arg standard_kit_configuration)"
+      custom_configuration="$(arg custom_configuration)" >
+    </xacro:outdoornav_sensors>
   </xacro:if>
 
   <gazebo>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -126,7 +126,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="cpr_urdf_extras" default="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
 
   <!-- OutdoorNav -->
-  <xacro:arg name="outdoornav_enable"          default="$(optenv OUTDOORNAV_ENABLE 0)" />
+  <xacro:arg name="outdoornav_enabled"         default="$(optenv OUTDOORNAV_ENABLED 0)" />
   <xacro:arg name="starter_kit_configuration"  default="$(optenv STARTER_KIT_CONFIGURATION 0)" />
   <xacro:arg name="standard_kit_configuration" default="$(optenv STANDARD_KIT_CONFIGURATION 0)" />
   <xacro:arg name="custom_configuration"       default="$(optenv CUSTOM_CONFIGURATION 0)" />
@@ -341,7 +341,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </xacro:if>
 
   <!-- OutdoorNav URDF Config -->
-  <xacro:if value="$(arg outdoornav_enable)">
+  <xacro:if value="$(arg outdoornav_enabled)">
     <xacro:include filename="$(find cpr_onav_description)/urdf/outdoornav_description.urdf.xacro" />
     <xacro:outdoornav_sensors
       starter_kit_configuration="$(arg starter_kit_configuration)"


### PR DESCRIPTION
Added the option to extend the URDF with the OutdoorNav links. Including:

- Starter Kit
- Standard Kit
- Custom

New dependency: cpr_onav_description