### PR TITLE
Only Included Realsense if Enabled

### DIFF
--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -271,17 +271,21 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </xacro:if>
 
   <!-- Intel Realsense Primary and Secondary -->
-  <xacro:if value="${realsense_model == 'd435'}">
-    <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
-  </xacro:if>
-  <xacro:if value="${realsense_model == 'd435i'}">
-    <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro" />
-  </xacro:if>
-  <xacro:if value="${realsense_model == 'd415'}">
-    <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
-  </xacro:if>
-  <xacro:if value="${realsense_model == 'd455'}">
-    <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  <xacro:property name="realsense_enabled" value="$(arg realsense_enabled)"/>
+  <xacro:property name="realsense_secondary_enabled" value="$(arg realsense_secondary_enabled)"/>
+  <xacro:if value="${realsense_enabled or realsense_secondary_enabled}">
+      <xacro:if value="${realsense_model == 'd435'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+      </xacro:if>
+      <xacro:if value="${realsense_model == 'd435i'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro" />
+      </xacro:if>
+      <xacro:if value="${realsense_model == 'd415'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
+      </xacro:if>
+      <xacro:if value="${realsense_model == 'd455'}">
+        <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+      </xacro:if>
   </xacro:if>
 
   <xacro:if value="$(arg realsense_enabled)">


### PR DESCRIPTION
If someone wanted to include realsense using `URDF_EXTRAS` they would be met by the global materials issue (i.e. repeated includes fail) that Intel has not resolved in their latest release. 