### PR TITLE
Add simplified collision geometry to Hokuyo model

### DIFF
--- a/husky_description/urdf/accessories/hokuyo_ust10.urdf.xacro
+++ b/husky_description/urdf/accessories/hokuyo_ust10.urdf.xacro
@@ -66,6 +66,18 @@
         </geometry>
         <material name="dark_grey" />
       </visual>
+      <collision>
+        <origin xyz="0 0 0.0175" rpy="0 0 0" />
+        <geometry>
+          <box size="0.05 0.05 0.035" />
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0 0.035" rpy="0 0 0" />
+        <geometry>
+          <cylinder radius="0.024" length="0.07" />
+        </geometry>
+      </collision>
     </link>
 
     <joint name="${prefix}_laser_joint" type="fixed">


### PR DESCRIPTION
The Hokuyo lidar doesn't have a `collision` tag. This adds a simplified version of the lidar using `box` & `cylinder` colliders to approximate the shape to allow e.g. MoveIt to avoid colliding with a protruding lidar.