### PR TITLE
Add support for mock hardware "simulation" and clean how parameters and arguments in macro are handled.

### DIFF
--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -5,12 +5,15 @@
   <!-- <xacro:arg name="name" default="" /> -->
 
   <xacro:arg name="prefix" default="" />
+  <xacro:arg name="is_sim" default="false" />
+  <xacro:arg name="use_mock_hardware" default="false" />
+
   <xacro:arg name="gazebo_controllers" default="$(find husky_control)/config/control.yaml" />
 
   <xacro:include filename="$(find husky_description)/urdf/husky_macro.urdf.xacro" />
 
   <!-- Load husky description -->
-  <xacro:husky prefix="$(arg prefix)" />
+  <xacro:husky prefix="$(arg prefix)" is_sim="$(arg is_sim)" use_mock_hardware="$(arg use_mock_hardware)" />
 
 
   <xacro:if value="$(arg is_sim)">

--- a/husky_description/urdf/husky_macro.urdf.xacro
+++ b/husky_description/urdf/husky_macro.urdf.xacro
@@ -14,7 +14,6 @@
   <xacro:property name="husky_rear_bumper_extend" value="$(optenv HUSKY_REAR_BUMPER_EXTEND 0)" />
 
   <xacro:arg name="robot_namespace" default="/" />
-  <xacro:arg name="is_sim" default="false" />
   <xacro:arg name="urdf_extras" default="$(optenv CPR_URDF_EXTRAS empty.urdf)" />
 
   <!-- Included URDF/XACRO Files -->
@@ -27,7 +26,7 @@
 
   <xacro:property name="M_PI" value="3.14159"/>
 
-  <xacro:macro name="husky" params="prefix">
+  <xacro:macro name="husky" params="prefix is_sim use_mock_hardware">
 
     <!-- Base Size -->
     <xacro:property name="base_x_size" value="0.98740000" />
@@ -163,14 +162,15 @@
 
     <ros2_control name="${prefix}husky_hardware" type="system">
       <hardware>
-        <xacro:if value="$(arg is_sim)">
+        <xacro:if value="${is_sim}">
           <plugin>gazebo_ros2_control/GazeboSystem</plugin>
         </xacro:if>
-        <xacro:unless value="$(arg is_sim)">
+        <xacro:if value="${use_mock_hardware}">
+          <plugin>mock_components/GenericSystem</plugin>
+          <param name="calculate_dynamics">true</param>
+        </xacro:if>
+        <xacro:unless value="${is_sim or use_mock_hardware}">
           <plugin>husky_base/HuskyHardware</plugin>
-          <plugin>fake_components/GenericSystem</plugin>
-          <param name="hw_start_duration_sec">2.0</param>
-          <param name="hw_stop_duration_sec">3.0</param>
           <param name="wheel_diameter">0.3302</param>
           <param name="max_accel">5.0</param>
           <param name="max_speed">1.0</param>


### PR DESCRIPTION
This PR adds the possibility for trivial mocking of hardware for testing ros2_control in more complex setup and developing without access to the robot.

The PR depends on the functionality added in ros-controls/ros2_control#1028 that enables simple dynamic calculation, i.e., calculates joint positions from velocities.

Furthermore, I used the opportunity to clean up a bit handling of parameters and arguments in XACRO files to hopefully add flexibility and reduce confusion.