### PR TITLE
Mod: Set 'publish_cmd' param to true in husky_control/config

### DIFF
--- a/husky_control/config/control.yaml
+++ b/husky_control/config/control.yaml
@@ -12,6 +12,9 @@ husky_velocity_controller:
   cmd_vel_timeout: 0.25
   velocity_rolling_window_size: 2
 
+  # Publish final output cmd_vel to /husky_velocity_controller/cmd_vel_out
+  publish_cmd: true
+
   # Base frame_id
   base_frame_id: base_link
 


### PR DESCRIPTION
- With this change the diff drive controller will output the final cmd_vel to /husky_velocity_controller/cmd_vel_out after any filters are applied (e.g., speed/acceleration limits).